### PR TITLE
Add category-aware personal reports for participants

### DIFF
--- a/answer.php
+++ b/answer.php
@@ -86,9 +86,15 @@ if (!$preview && is_post()) {
     }
 
     if (empty($errors)) {
-        $surveyService->recordResponse($surveyId, $participant['id'] ?? null, $answers);
-        $_SESSION['survey_completed'] = true;
-        redirect('thank_you.php');
+        $responseId = $surveyService->recordResponse($surveyId, $participant['id'] ?? null, $answers);
+        $_SESSION['personal_report_response'] = $responseId;
+
+        $redirectUrl = 'personal_report.php?response=' . $responseId;
+        if (!empty($participant['token'])) {
+            $redirectUrl .= '&token=' . urlencode($participant['token']);
+        }
+
+        redirect($redirectUrl);
     }
 }
 

--- a/database.sql
+++ b/database.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS survey_questions (
     survey_id INT UNSIGNED NOT NULL,
     question_text TEXT NOT NULL,
     question_type ENUM('multiple_choice','rating','text') NOT NULL,
+    category_key VARCHAR(100) NULL,
     is_required TINYINT(1) NOT NULL DEFAULT 0,
     max_length INT NULL,
     order_index INT NOT NULL DEFAULT 0,
@@ -147,6 +148,7 @@ ON DUPLICATE KEY UPDATE
     survey_id = VALUES(survey_id),
     question_text = VALUES(question_text),
     question_type = VALUES(question_type),
+    category_key = VALUES(category_key),
     is_required = VALUES(is_required),
     max_length = VALUES(max_length),
     order_index = VALUES(order_index);

--- a/participants.php
+++ b/participants.php
@@ -84,6 +84,7 @@ include __DIR__ . '/templates/navbar.php';
                         <th>Davet</th>
                         <th>Durum</th>
                         <th>Link</th>
+                        <th>Rapor</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -95,6 +96,13 @@ include __DIR__ . '/templates/navbar.php';
                             <td><?php echo $participant['invited_at'] ? h(format_date($participant['invited_at'], 'd.m.Y H:i')) : '-'; ?></td>
                             <td><?php echo $participant['responded_at'] ? '<span class="status status-active">Tamamlandi</span>' : '<span class="status status-draft">Bekliyor</span>'; ?></td>
                             <td><input type="text" readonly value="<?php echo h($link); ?>" onclick="this.select();"></td>
+                            <td>
+                                <?php if ($participant['responded_at']): ?>
+                                    <a class="button-link" href="personal_report.php?participant=<?php echo (int)$participant['id']; ?>">Raporu Gör</a>
+                                <?php else: ?>
+                                    -
+                                <?php endif; ?>
+                            </td>
                             <td>
                                 <a class="button-link" href="participants.php?id=<?php echo $surveyId; ?>&send=<?php echo (int)$participant['id']; ?>">E-posta Gonder</a>
                             </td>

--- a/personal_report.php
+++ b/personal_report.php
@@ -2,20 +2,28 @@
 require __DIR__ . '/includes/bootstrap.php';
 
 $responseId = isset($_GET['response']) ? (int)$_GET['response'] : 0;
+$participantId = isset($_GET['participant']) ? (int)$_GET['participant'] : 0;
 $token = $_GET['token'] ?? null;
 
-if ($responseId <= 0) {
+if ($participantId > 0) {
+    $bundle = $surveyService->getParticipantResponses($participantId);
+} elseif ($responseId > 0) {
+    $bundle = $surveyService->getResponseReport($responseId);
+} else {
     http_response_code(404);
-    exit('Rapor bulunamadý.');
+    exit('Rapor bulunamadÄ±.');
 }
 
-$report = $surveyService->generatePersonalReport($responseId);
+$report = $surveyService->generatePersonalReport($bundle);
 if (!$report) {
     http_response_code(404);
-    exit('Rapor bulunamadý.');
+    exit('Rapor bulunamadÄ±.');
 }
 
+$surveyMeta = is_array($report['survey'] ?? null) ? $report['survey'] : [];
 $participantInfo = $report['participant'] ?? [];
+$responseMeta = is_array($report['response'] ?? null) ? $report['response'] : [];
+$responseId = $responseMeta['id'] ?? $responseId;
 $allowed = false;
 
 if (current_user_id()) {
@@ -30,18 +38,20 @@ if (current_user_id()) {
 
 if (!$allowed) {
     http_response_code(403);
-    exit('Bu rapora eriþim yetkiniz yok.');
+    exit('Bu rapora eriÅŸim yetkiniz yok.');
 }
 
 if (!empty($_SESSION['personal_report_response']) && (int)$_SESSION['personal_report_response'] === $responseId) {
     unset($_SESSION['personal_report_response']);
 }
 
-$submittedAt = $report['response']['submitted_at'] ?? null;
+$responseMeta = is_array($responseMeta) ? $responseMeta : [];
+$submittedAt = $responseMeta['submitted_at'] ?? null;
+$hasCategories = !empty($report['categories']);
 $averageScore = $report['overview']['average_score'] ?? null;
 $strengths = $report['overview']['strengths'] ?? [];
 $gaps = $report['overview']['gaps'] ?? [];
-$advice = $report['advice'] ?? '';
+$advice = $hasCategories ? ($report['advice'] ?? '') : '';
 
 include __DIR__ . '/templates/header.php';
 if (current_user_id()) {
@@ -51,14 +61,17 @@ if (current_user_id()) {
 <main class="container personal-report">
     <section class="panel">
         <div class="panel-header">
-            <h1>Kiþisel Güvenlik Raporu</h1>
+            <h1>KiÅŸisel GÃ¼venlik Raporu</h1>
             <?php if ($submittedAt): ?>
                 <span class="badge badge-time"><?php echo h(format_date($submittedAt, 'd.m.Y H:i')); ?></span>
             <?php endif; ?>
         </div>
         <div class="panel-body">
+            <?php if (!empty($surveyMeta['title'])): ?>
+                <p class="report-subtitle">Anket: <?php echo h($surveyMeta['title']); ?></p>
+            <?php endif; ?>
             <?php if (!empty($participantInfo['email'])): ?>
-                <p class="report-subtitle">Sayýn <?php echo h($participantInfo['email']); ?>, verdiðiniz yanýtlarýn kýsa özeti:</p>
+                <p class="report-subtitle">SayÄ±n <?php echo h($participantInfo['email']); ?>, verdiÄŸiniz yanÄ±tlarÄ±n kÄ±sa Ã¶zeti:</p>
             <?php endif; ?>
             <div class="report-overview">
                 <div class="overview-item">
@@ -66,50 +79,58 @@ if (current_user_id()) {
                     <span class="value"><?php echo $averageScore !== null ? h($averageScore) : ' - '; ?></span>
                 </div>
                 <div class="overview-item">
-                    <span class="label">Güçlü Alanlar</span>
-                    <span class="value"><?php echo $strengths ? h(implode(', ', $strengths)) : 'Henüz belirlenmedi'; ?></span>
+                    <span class="label">GÃ¼Ã§lÃ¼ Alanlar</span>
+                    <span class="value"><?php echo $strengths ? h(implode(', ', $strengths)) : 'HenÃ¼z belirlenmedi'; ?></span>
                 </div>
                 <div class="overview-item">
-                    <span class="label">Geliþim Alanlarý</span>
+                    <span class="label">GeliÅŸim AlanlarÄ±</span>
                     <span class="value"><?php echo $gaps ? h(implode(', ', $gaps)) : 'Belirlenmedi'; ?></span>
                 </div>
             </div>
         </div>
     </section>
 
-    <?php foreach ($report['categories'] as $category): ?>
+    <?php if ($hasCategories): ?>
+        <?php foreach ($report['categories'] as $category): ?>
+            <section class="panel category-card">
+                <div class="panel-header">
+                    <h2><?php echo h($category['label']); ?></h2>
+                    <?php if ($category['average_score'] !== null): ?>
+                        <span class="badge badge-score"><?php echo h($category['average_score']); ?></span>
+                    <?php endif; ?>
+                </div>
+                <div class="panel-body">
+                    <ul class="answer-list">
+                        <?php foreach ($category['questions'] as $question): ?>
+                            <li>
+                                <strong><?php echo h($question['question']); ?></strong>
+                                <div class="answer-value">
+                                    <?php if ($question['type'] === 'rating'): ?>
+                                        <span class="score-chip">Puan: <?php echo h($question['answer']); ?></span>
+                                    <?php elseif ($question['type'] === 'multiple_choice'): ?>
+                                        <span class="choice-chip"><?php echo h($question['answer']); ?></span>
+                                    <?php else: ?>
+                                        <span class="text-answer"><?php echo nl2br(h($question['answer'] ?? '')); ?></span>
+                                    <?php endif; ?>
+                                </div>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            </section>
+        <?php endforeach; ?>
+    <?php else: ?>
         <section class="panel category-card">
-            <div class="panel-header">
-                <h2><?php echo h($category['label']); ?></h2>
-                <?php if ($category['average_score'] !== null): ?>
-                    <span class="badge badge-score"><?php echo h($category['average_score']); ?></span>
-                <?php endif; ?>
-            </div>
             <div class="panel-body">
-                <ul class="answer-list">
-                    <?php foreach ($category['questions'] as $question): ?>
-                        <li>
-                            <strong><?php echo h($question['question']); ?></strong>
-                            <div class="answer-value">
-                                <?php if ($question['type'] === 'rating'): ?>
-                                    <span class="score-chip">Puan: <?php echo h($question['answer']); ?></span>
-                                <?php elseif ($question['type'] === 'multiple_choice'): ?>
-                                    <span class="choice-chip"><?php echo h($question['answer']); ?></span>
-                                <?php else: ?>
-                                    <span class="text-answer"><?php echo nl2br(h($question['answer'] ?? '')); ?></span>
-                                <?php endif; ?>
-                            </div>
-                        </li>
-                    <?php endforeach; ?>
-                </ul>
+                <p>Bu katÄ±lÄ±mcÄ± iÃ§in henÃ¼z yanÄ±t kaydedilmemiÅŸtir.</p>
             </div>
         </section>
-    <?php endforeach; ?>
+    <?php endif; ?>
 
     <?php if (!empty($advice)): ?>
         <section class="panel">
             <div class="panel-header">
-                <h2>Önerilen Aksiyon Planý</h2>
+                <h2>Ã–nerilen Aksiyon PlanÄ±</h2>
             </div>
             <div class="panel-body">
                 <p class="advice-text"><?php echo nl2br(h($advice)); ?></p>
@@ -119,9 +140,9 @@ if (current_user_id()) {
 
     <section class="panel">
         <div class="panel-body report-actions">
-            <a class="button-secondary" href="thank_you.php">Dönüþ Yap</a>
-            <?php if (current_user_id()): ?>
-                <a class="button-secondary" href="survey_reports.php?id=<?php echo (int)$report['survey']['id']; ?>">Anket Raporuna Git</a>
+            <a class="button-secondary" href="index.php">Ana Sayfaya DÃ¶n</a>
+            <?php if (current_user_id() && !empty($surveyMeta['id'])): ?>
+                <a class="button-secondary" href="survey_reports.php?id=<?php echo (int)$surveyMeta['id']; ?>">Anket Raporuna Git</a>
             <?php endif; ?>
         </div>
     </section>

--- a/readme.rd
+++ b/readme.rd
@@ -1,55 +1,55 @@
-# Anketor - Kişiye Özel Siber Güvenlik Raporlama
+# Anketor - KiÅŸiye Ã–zel Siber GÃ¼venlik Raporlama
 
-Anketor artık her katılımcıya, verdiği yanıtlara göre kişiselleştirilmiş siber güvenlik geri bildirimi sağlayan bir platformdur. Web uygulaması ve e-posta güvenliği gibi tema başlıklarına göre soruları kategorize eder, katılımcının güçlü yönlerini ve geliştirmesi gereken alanları madde madde raporlar.
+Anketor artÄ±k her katÄ±lÄ±mcÄ±ya, verdiÄŸi yanÄ±tlara gÃ¶re kiÅŸiselleÅŸtirilmiÅŸ siber gÃ¼venlik geri bildirimi saÄŸlayan bir platformdur. Web uygulamasÄ± ve e-posta gÃ¼venliÄŸi gibi tema baÅŸlÄ±klarÄ±na gÃ¶re sorularÄ± kategorize eder, katÄ±lÄ±mcÄ±nÄ±n gÃ¼Ã§lÃ¼ yÃ¶nlerini ve geliÅŸtirmesi gereken alanlarÄ± madde madde raporlar.
 
-## Öne Çıkanlar
-- Web ve e-posta güvenliği kategorileri için tek ankette birden fazla bölüm
-- Katılımcı akışı sonunda otomatik kişisel rapor (anonim token ile erişim)
-- OpenAI desteği aktifse kişiye özel aksiyon önerileri, aksi halde yerleşik fallback tavsiyeler
-- Admin panelinden katılımcı başına rapor görüntüleme ve e-posta davet takibi
-- PDF/CSV/SVG kurum raporları hâlâ mevcut; bireysel rapor bunların tamamlayıcısıdır
+## Ã–ne Ã‡Ä±kanlar
+- Web ve e-posta gÃ¼venliÄŸi kategorileri iÃ§in tek ankette birden fazla bÃ¶lÃ¼m
+- KatÄ±lÄ±mcÄ± akÄ±ÅŸÄ± sonunda otomatik kiÅŸisel rapor (anonim token ile eriÅŸim)
+- OpenAI desteÄŸi aktifse kiÅŸiye Ã¶zel aksiyon Ã¶nerileri, aksi halde yerleÅŸik fallback tavsiyeler
+- Admin panelinden katÄ±lÄ±mcÄ± baÅŸÄ±na rapor gÃ¶rÃ¼ntÃ¼leme ve e-posta davet takibi
+- PDF/CSV/SVG kurum raporlarÄ± hÃ¢lÃ¢ mevcut; bireysel rapor bunlarÄ±n tamamlayÄ±cÄ±sÄ±dÄ±r
 
 ## Kurulum
-1. `config.sample.php` dosyasını `config.php` olarak kopyalayın ve MySQL / mail / OpenAI bilgilerinizi girin.
-2. `install.php` sayfasını çalıştırdığınızda veritabanı mevcut değilse otomatik olarak oluşturulur ve demo verisi yüklenir. Sonrasında güvenlik için bu dosyayı kaldırmayı unutmayın.
-3. Varsayılan yönetici hesabı:
+1. `config.sample.php` dosyasÄ±nÄ± `config.php` olarak kopyalayÄ±n ve MySQL / mail / OpenAI bilgilerinizi girin.
+2. `install.php` sayfasÄ±nÄ± Ã§alÄ±ÅŸtÄ±rdÄ±ÄŸÄ±nÄ±zda veritabanÄ± mevcut deÄŸilse otomatik olarak oluÅŸturulur ve demo verisi yÃ¼klenir. SonrasÄ±nda gÃ¼venlik iÃ§in bu dosyayÄ± kaldÄ±rmayÄ± unutmayÄ±n.
+3. VarsayÄ±lan yÃ¶netici hesabÄ±:
    - E-posta: `admin@example.com`
-   - Şifre: `YeniParola123!`
-4. Giriş yaptıktan sonra `Anketler > Katılımcılar` bölümünden rapor linklerini test edebilirsiniz.
+   - Åifre: `YeniParola123!`
+4. GiriÅŸ yaptÄ±ktan sonra `Anketler > KatÄ±lÄ±mcÄ±lar` bÃ¶lÃ¼mÃ¼nden rapor linklerini test edebilirsiniz.
 
-## Veritabanı Yapısı
-- `survey_questions` tablosunda her soru için `category_key` alanı bulunur. Kişisel rapor kategorilerini bu anahtar üzerinden üretir.
-- `survey_responses` ile `response_answers` katılımcı yanıtlarını taşır. Yönlendirme token'ı `survey_participants.token` alanındadır.
+## VeritabanÄ± YapÄ±sÄ±
+- `survey_questions` tablosunda her soru iÃ§in `category_key` alanÄ± bulunur. KiÅŸisel rapor kategorilerini bu anahtar Ã¼zerinden Ã¼retir.
+- `survey_responses` ile `response_answers` katÄ±lÄ±mcÄ± yanÄ±tlarÄ±nÄ± taÅŸÄ±r. YÃ¶nlendirme token'Ä± `survey_participants.token` alanÄ±ndadÄ±r.
 
 ### Demo Verisi
-Kurulumdan sonra gelen örnekler:
-- Anket: **2025 Siber Güvenlik Kişisel Değerlendirme** (kategori anahtarları: `web_guvenligi`, `eposta_guvenligi`)
-- Katılımcı token'ları: `sec-2025-a1`, `sec-2025-b2`, `phish-2024-a1`, `phish-2024-b2`
-- Rapor örneği: `personal_report.php?response=1&token=sec-2025-a1`
+Kurulumdan sonra gelen Ã¶rnekler:
+- Anket: **2025 Siber GÃ¼venlik KiÅŸisel DeÄŸerlendirme** (kategori anahtarlarÄ±: `web_guvenligi`, `eposta_guvenligi`)
+- KatÄ±lÄ±mcÄ± token'larÄ±: `sec-2025-a1`, `sec-2025-b2`, `phish-2024-a1`, `phish-2024-b2`
+- Rapor Ã¶rneÄŸi: `personal_report.php?response=1&token=sec-2025-a1`
 
-## Yönetici Akışı
-1. `dashboard.php` – özet metrikler.
-2. `survey_edit.php` – anket meta bilgisi (tarih, durum, kategori).
-3. `survey_questions.php` – soru ekleme, kategori anahtarı giriş alanı ve AI öneri formu.
-4. `participants.php` – katılımcı listesi, davet maili gönderme, “Raporu Gör” bağlantısı.
-5. `survey_reports.php` – kurumsal PDF/CSV/SVG çıktıları, trend kıyasları ve akıllı rapor.
+## YÃ¶netici AkÄ±ÅŸÄ±
+1. `dashboard.php` â€“ Ã¶zet metrikler.
+2. `survey_edit.php` â€“ anket meta bilgisi (tarih, durum, kategori).
+3. `survey_questions.php` â€“ soru ekleme, kategori anahtarÄ± giriÅŸ alanÄ± ve AI Ã¶neri formu.
+4. `participants.php` â€“ katÄ±lÄ±mcÄ± listesi, davet maili gÃ¶nderme, â€œRaporu GÃ¶râ€ baÄŸlantÄ±sÄ±.
+5. `survey_reports.php` â€“ kurumsal PDF/CSV/SVG Ã§Ä±ktÄ±larÄ±, trend kÄ±yaslarÄ± ve akÄ±llÄ± rapor.
 
-## Katılımcı Deneyimi
-- Davet linki: `answer.php?id={survey_id}&token={token}` formatındadır.
-- Anket tamamlanınca kullanıcı `personal_report.php` sayfasına yönlendirilir; rapor bağlantısını saklayabilir.
-- Rapor ekranında güçlü alanlar, geliştirme alanları ve önerilen aksiyonlar açıkça listelenir. Admin girişi yapılmışsa panel navbarı görünür.
+## KatÄ±lÄ±mcÄ± Deneyimi
+- Davet linki: `answer.php?id={survey_id}&token={token}` formatÄ±ndadÄ±r.
+- Anket tamamlanÄ±nca kullanÄ±cÄ± `personal_report.php` sayfasÄ±na yÃ¶nlendirilir; rapor baÄŸlantÄ±sÄ±nÄ± saklayabilir.
+- Rapor ekranÄ±nda gÃ¼Ã§lÃ¼ alanlar, geliÅŸtirme alanlarÄ± ve Ã¶nerilen aksiyonlar aÃ§Ä±kÃ§a listelenir. Admin giriÅŸi yapÄ±lmÄ±ÅŸsa panel navbarÄ± gÃ¶rÃ¼nÃ¼r.
 
-## Kişisel Rapor Mantığı
-`SurveyService::generatePersonalReport()` katılımcı yanıtlarını kategori bazında gruplayıp ortalama skor, çoktan seçmeli tercih ve açık uçlu notları bir araya getirir. `AIClient::generatePersonalAdvice()` modeli tanımlıysa bu özetten anlamlı aksiyonlar üretir; aksi hâlde fallback metni kullanılır.
+## KiÅŸisel Rapor MantÄ±ÄŸÄ±
+`SurveyService::getParticipantResponses($participantId)` ilgili kiÅŸinin son yanÄ±t paketini (soru, seÃ§enek ve kategori anahtarÄ±yla) dÃ¶ndÃ¼rÃ¼r. Bu veri `SurveyService::generatePersonalReport(array $bundle)` ile iÅŸlenerek kategori bazlÄ± Ã¶zet, ortalama skor ve aksiyon Ã¶nerisi Ã¼retir. `AIClient::generatePersonalAdvice()` modeli tanÄ±mlÄ±ysa bu Ã¶zetin Ã¼stÃ¼ne kiÅŸiye Ã¶zel tavsiyeler ekler; aksi hÃ¢lde fallback metni devreye girer.
 
-## Kurulum Sayfası `install.php`
-- Veritabanı yoksa oluşturur, `database.sql` demo verisini yükler.
-- `CREATE DATABASE` veya `USE` komutları barındıran satırlar hosting kısıtına takılmasın diye otomatik atlanır.
-- Kurulum tamamlandıktan sonra admin paneline dönüş butonu sunar.
+## Kurulum SayfasÄ± `install.php`
+- VeritabanÄ± yoksa oluÅŸturur, `database.sql` demo verisini yÃ¼kler.
+- `CREATE DATABASE` veya `USE` komutlarÄ± barÄ±ndÄ±ran satÄ±rlar hosting kÄ±sÄ±tÄ±na takÄ±lmasÄ±n diye otomatik atlanÄ±r.
+- Kurulum tamamlandÄ±ktan sonra admin paneline dÃ¶nÃ¼ÅŸ butonu sunar.
 
-## Geliştirme Notları
-- Yeni soru eklerken `category_key` alanını doldurmayı unutmayın (örneğin `web_guvenligi`, `eposta_guvenligi`).
-- Kişisel rapor çıktısını genişletmek için `SurveyService::groupAnswersByCategory()` fonksiyonunda kategori bazlı hesaplamalar yapılmaktadır.
-- AI entegrasyonu kapalıysa `fallbackPersonalAdvice()` devreye girer.
+## GeliÅŸtirme NotlarÄ±
+- Yeni soru eklerken `category_key` alanÄ±nÄ± doldurmayÄ± unutmayÄ±n (Ã¶rneÄŸin `web_guvenligi`, `eposta_guvenligi`).
+- KiÅŸisel rapor Ã§Ä±ktÄ±sÄ±nÄ± geniÅŸletmek iÃ§in `SurveyService::groupAnswersByCategory()` fonksiyonunda kategori bazlÄ± hesaplamalar yapÄ±lmaktadÄ±r.
+- AI entegrasyonu kapalÄ±ysa `fallbackPersonalAdvice()` devreye girer.
 
-Demo veri ile oynayıp kişisel raporu deneyin; yeni kategoriler oluşturup farklı alanlar için (ör. mobil uygulama güvenliği, fiziksel güvenlik) anında yeni bölümler ekleyebilirsiniz.
+Demo veri ile oynayÄ±p kiÅŸisel raporu deneyin; yeni kategoriler oluÅŸturup farklÄ± alanlar iÃ§in (Ã¶r. mobil uygulama gÃ¼venliÄŸi, fiziksel gÃ¼venlik) anÄ±nda yeni bÃ¶lÃ¼mler ekleyebilirsiniz.

--- a/survey_question_edit.php
+++ b/survey_question_edit.php
@@ -28,6 +28,7 @@ if (is_post()) {
     $surveyService->updateQuestion($questionId, [
         'question_text' => trim($_POST['question_text'] ?? ''),
         'question_type' => $type,
+        'category_key' => trim($_POST['category_key'] ?? '') ?: null,
         'is_required' => !empty($_POST['is_required']),
         'max_length' => $type === 'text' ? (int)($_POST['max_length'] ?? 0) : null,
         'order_index' => (int)($_POST['order_index'] ?? 0),

--- a/survey_questions.php
+++ b/survey_questions.php
@@ -38,6 +38,7 @@ if (is_post()) {
         $surveyService->addQuestion($surveyId, [
             'question_text' => trim($_POST['question_text'] ?? ''),
             'question_type' => $type,
+            'category_key' => trim($_POST['category_key'] ?? '') ?: null,
             'is_required' => !empty($_POST['is_required']),
             'max_length' => $type === 'text' ? (int)($_POST['max_length'] ?? 0) : null,
             'order_index' => (int)($_POST['order_index'] ?? 0),
@@ -178,6 +179,9 @@ include __DIR__ . '/templates/navbar.php';
                             <div>
                                 <strong>#<?php echo (int)$question['order_index']; ?> &raquo; <?php echo h($question['question_text']); ?></strong>
                                 <span class="tag tag-<?php echo h($question['question_type']); ?>"><?php echo h($question['question_type']); ?></span>
+                                <?php if (!empty($question['category_key'])): ?>
+                                    <span class="tag tag-category"><?php echo h($question['category_key']); ?></span>
+                                <?php endif; ?>
                                 <?php if ($question['is_required']): ?><span class="tag">Zorunlu</span><?php endif; ?>
                             </div>
                             <?php if (!empty($question['options'])): ?>


### PR DESCRIPTION
## Summary
- add a category_key column to survey questions and persist it through CRUD flows
- expose participant-centric response retrieval and update the personal report experience to use it
- refresh the admin participants list with personal report access and document the new workflow

## Testing
- php -l includes/services/SurveyService.php
- php -l survey_questions.php
- php -l survey_question_edit.php
- php -l answer.php
- php -l personal_report.php
- php -l participants.php

------
https://chatgpt.com/codex/tasks/task_e_68e2e7a6ca60832ea9a3adf44fce765d