### PR TITLE
Fix category persistence for survey questions

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -459,26 +459,244 @@ textarea {
     font-size: 0.85rem;
 }
 
-@media (max-width: 768px) {
-    .top-nav {
-        flex-direction: column;
-        gap: 1rem;
-    }
-
-    .inline-form,
-    .inline-actions,
-    .form-actions {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .panel-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 1rem;
-    }
+.eyebrow {
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    color: var(--color-muted);
+    font-weight: 600;
+    margin-bottom: 0.5rem;
 }
-\n.keyword-cloud {\n    display: flex;\n    flex-wrap: wrap;\n    gap: 0.5rem;\n}\n
+
+.page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    margin-bottom: 2.5rem;
+}
+
+.page-header__actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.page-subtitle {
+    color: var(--color-muted);
+    margin-top: 0.35rem;
+    font-size: 0.95rem;
+}
+
+.hero-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+    gap: 2.5rem;
+    padding: 2.5rem;
+    border-radius: var(--radius);
+    background: linear-gradient(135deg, rgba(60, 109, 240, 0.08), rgba(255, 255, 255, 0.9));
+    box-shadow: var(--shadow);
+    margin-bottom: 2.5rem;
+    align-items: center;
+}
+
+.hero-card__content h1 {
+    margin: 0;
+}
+
+.hero-lead {
+    font-size: 1.05rem;
+    color: var(--color-muted);
+    margin: 0.75rem 0 1.5rem;
+    max-width: 520px;
+}
+
+.hero-metrics {
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.metric {
+    background: rgba(255, 255, 255, 0.7);
+    border-radius: 16px;
+    padding: 1rem 1.25rem;
+    box-shadow: 0 6px 16px rgba(60, 109, 240, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 160px;
+}
+
+.metric-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    letter-spacing: 0.08em;
+}
+
+.metric-value {
+    font-size: 1.4rem;
+    font-weight: 700;
+}
+
+.hero-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.hero-card__sidebar {
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: var(--radius);
+    padding: 1.75rem;
+    box-shadow: 0 14px 28px rgba(31, 41, 55, 0.08);
+}
+
+.hero-card__sidebar h3 {
+    margin-top: 0;
+    margin-bottom: 1.2rem;
+    font-size: 1.05rem;
+}
+
+.quick-actions {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.quick-actions li {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.75rem;
+    align-items: flex-start;
+}
+
+.quick-actions__icon {
+    font-size: 1.4rem;
+    line-height: 1;
+}
+
+.quick-actions strong {
+    display: block;
+    margin-bottom: 0.2rem;
+}
+
+.quick-actions small {
+    color: var(--color-muted);
+}
+
+.empty-state {
+    text-align: center;
+    padding: 3rem 2rem;
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 1rem;
+    justify-items: center;
+}
+
+.empty-state h2 {
+    margin: 0;
+}
+
+.survey-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.survey-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--radius);
+    padding: 1.75rem;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.survey-card__header h2 {
+    margin: 0.5rem 0 0.75rem;
+    font-size: 1.2rem;
+}
+
+.survey-card__header p {
+    color: var(--color-muted);
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+.survey-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+}
+
+.survey-meta dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-muted);
+    margin-bottom: 0.25rem;
+}
+
+.survey-meta dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.survey-card__actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.stacked-form {
+    display: grid;
+    gap: 1.2rem;
+    max-width: 640px;
+}
+
+.knowledge-list {
+    list-style: none;
+    padding: 0;
+    margin: 2rem 0 0;
+    display: grid;
+    gap: 1.2rem;
+}
+
+.knowledge-item {
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: var(--radius);
+    padding: 1.25rem 1.5rem;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 0.5rem;
+}
+
+.knowledge-item header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+}
+
+.knowledge-item p {
+    margin: 0;
+    color: var(--color-text);
+}
+
+.keyword-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
 .personal-report .report-overview {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -578,4 +796,40 @@ textarea {
     gap: 1rem;
     justify-content: flex-end;
     flex-wrap: wrap;
+}
+
+@media (max-width: 1024px) {
+    .hero-card {
+        grid-template-columns: 1fr;
+    }
+
+    .hero-card__sidebar {
+        order: -1;
+    }
+}
+
+@media (max-width: 768px) {
+    .top-nav {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: flex-start;
+    }
+
+    .page-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .page-header__actions,
+    .hero-actions,
+    .inline-form,
+    .inline-actions,
+    .form-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .survey-card {
+        padding: 1.5rem;
+    }
 }

--- a/dashboard.php
+++ b/dashboard.php
@@ -10,6 +10,10 @@ $stats = [
 ];
 
 $recentSurveys = $surveyService->getSurveys(5);
+$primarySurvey = $recentSurveys[0] ?? null;
+$totalInvites = (int)$stats['responses'] + (int)$stats['pending'];
+$responseRate = $totalInvites > 0 ? round(($stats['responses'] / $totalInvites) * 100) : 0;
+$pageTitle = 'Gösterge Paneli - ' . config('app.name', 'Anketor');
 $flash = get_flash();
 include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
@@ -18,6 +22,57 @@ include __DIR__ . '/templates/navbar.php';
     <?php if ($flash): ?>
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
     <?php endif; ?>
+
+    <section class="hero-card">
+        <div class="hero-card__content">
+            <p class="eyebrow">Kontrol Merkezi</p>
+            <h1>Merhaba <?php echo h(current_user_name()); ?></h1>
+            <p class="hero-lead">Ekibinizin siber güvenlik nabzını buradan yönetin. <?php echo (int)$stats['active']; ?> aktif anket ve <?php echo (int)$stats['pending']; ?> bekleyen davet sizi bekliyor.</p>
+            <div class="hero-metrics">
+                <div class="metric">
+                    <span class="metric-label">Yanıt Oranı</span>
+                    <strong class="metric-value"><?php echo $totalInvites > 0 ? $responseRate . '%': 'N/A'; ?></strong>
+                </div>
+                <div class="metric">
+                    <span class="metric-label">Son Anket</span>
+                    <strong class="metric-value"><?php echo $primarySurvey ? h($primarySurvey['title']) : 'Henüz yok'; ?></strong>
+                </div>
+            </div>
+            <div class="hero-actions">
+                <a class="button-primary" href="survey_edit.php">Yeni Anket Oluştur</a>
+                <?php if (!empty($primarySurvey['id'])): ?>
+                    <a class="button-secondary" href="participants.php?id=<?php echo (int)$primarySurvey['id']; ?>">Katılımcıları Yönet</a>
+                <?php endif; ?>
+                <a class="button-link" href="reports.php">Rapor Merkezi</a>
+            </div>
+        </div>
+        <div class="hero-card__sidebar">
+            <h3>Hızlı İşlemler</h3>
+            <ul class="quick-actions">
+                <li>
+                    <span class="quick-actions__icon">✨</span>
+                    <span>
+                        <strong>AI önerilerini güncelleyin</strong>
+                        <small>Raporlardan manuel not ekleyerek kişisel önerileri güçlendirin.</small>
+                    </span>
+                </li>
+                <li>
+                    <span class="quick-actions__icon">🗂️</span>
+                    <span>
+                        <strong>Soru havuzunu düzenleyin</strong>
+                        <small>Hazır soruları anketlere tek tıkla ekleyin.</small>
+                    </span>
+                </li>
+                <li>
+                    <span class="quick-actions__icon">📧</span>
+                    <span>
+                        <strong>Davetleri yeniden gönderin</strong>
+                        <small>Katılım oranını artırmak için hatırlatma planlayın.</small>
+                    </span>
+                </li>
+            </ul>
+        </div>
+    </section>
 
     <section class="stats-grid">
         <div class="stat-card">
@@ -41,20 +96,20 @@ include __DIR__ . '/templates/navbar.php';
     <section class="panel">
         <div class="panel-header">
             <h2>Son Anketler</h2>
-            <a class="button-primary" href="survey_edit.php">Yeni Anket</a>
+            <a class="button-secondary" href="surveys.php">Tümünü Gör</a>
         </div>
         <div class="panel-body">
             <?php if (empty($recentSurveys)): ?>
-                <p>Hen�z anket bulunmuyor.</p>
+                <p>Henüz anket bulunmuyor.</p>
             <?php else: ?>
                 <table class="table">
                     <thead>
                         <tr>
-                            <th>Baslik</th>
+                            <th>Başlık</th>
                             <th>Kategori</th>
                             <th>Durum</th>
-                            <th>Baslangic</th>
-                            <th>Bitis</th>
+                            <th>Başlangıç</th>
+                            <th>Bitiş</th>
                             <th></th>
                         </tr>
                     </thead>
@@ -67,7 +122,7 @@ include __DIR__ . '/templates/navbar.php';
                                 <td><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></td>
                                 <td><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></td>
                                 <td>
-                                    <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Duzenle</a>
+                                    <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Düzenle</a>
                                     <a class="button-link" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Sorular</a>
                                 </td>
                             </tr>

--- a/database.sql
+++ b/database.sql
@@ -56,6 +56,25 @@ CREATE TABLE IF NOT EXISTS question_options (
     CONSTRAINT fk_options_question FOREIGN KEY (question_id) REFERENCES survey_questions(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS question_library (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    question_text TEXT NOT NULL,
+    question_type ENUM('multiple_choice','rating','text') NOT NULL,
+    category_key VARCHAR(120) NULL,
+    is_required TINYINT(1) NOT NULL DEFAULT 0,
+    max_length INT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS question_library_options (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    library_question_id INT UNSIGNED NOT NULL,
+    option_text VARCHAR(255) NOT NULL,
+    option_value VARCHAR(100) NULL,
+    order_index INT NOT NULL DEFAULT 0,
+    CONSTRAINT fk_library_options_question FOREIGN KEY (library_question_id) REFERENCES question_library(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS survey_participants (
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     survey_id INT UNSIGNED NOT NULL,
@@ -162,6 +181,35 @@ INSERT INTO question_options (id, question_id, option_text, option_value, order_
 
 ON DUPLICATE KEY UPDATE
     question_id = VALUES(question_id),
+    option_text = VALUES(option_text),
+    option_value = VALUES(option_value),
+    order_index = VALUES(order_index);
+
+INSERT INTO question_library (id, question_text, question_type, category_key, is_required, max_length, created_at) VALUES
+    (1, 'Web uygulamalarinda guclu parola kullanirim.', 'rating', 'web_guvenligi', 1, NULL, '2025-02-20 09:05:00'),
+    (2, 'Cok faktorlu kimlik dogrulamasini hangi siklikla etkinlestiriyorsunuz?', 'multiple_choice', 'web_guvenligi', 1, NULL, '2025-02-20 09:06:00'),
+    (3, 'Web guvenligini artirmak icin hangi desteklere ihtiyaciniz var?', 'text', 'web_guvenligi', 0, 400, '2025-02-20 09:07:00'),
+    (4, 'Supheli e-postalari tanima becerimi 1-5 arasinda puanlarim.', 'rating', 'eposta_guvenligi', 1, NULL, '2024-10-01 09:40:00'),
+    (5, 'Olta saldirisi oldugunu dusundugunuz maili nasil raporlarsiniz?', 'multiple_choice', 'eposta_guvenligi', 1, NULL, '2024-10-01 09:41:00'),
+    (6, 'E-posta saldirilarina karsi daha guvende hissetmek icin ne gerekir?', 'text', 'eposta_guvenligi', 0, 400, '2024-10-01 09:42:00')
+
+ON DUPLICATE KEY UPDATE
+    question_text = VALUES(question_text),
+    question_type = VALUES(question_type),
+    category_key = VALUES(category_key),
+    is_required = VALUES(is_required),
+    max_length = VALUES(max_length);
+
+INSERT INTO question_library_options (id, library_question_id, option_text, option_value, order_index) VALUES
+    (1, 2, 'Her zaman', NULL, 1),
+    (2, 2, 'Cogu uygulamada', NULL, 2),
+    (3, 2, 'Nadiren', NULL, 3),
+    (4, 5, 'Aninda guvenlik ekibine bildiririm', NULL, 1),
+    (5, 5, 'Ekibime iletir ve teyit beklerim', NULL, 2),
+    (6, 5, 'Yanlislikla siler ya da yok sayarim', NULL, 3)
+
+ON DUPLICATE KEY UPDATE
+    library_question_id = VALUES(library_question_id),
     option_text = VALUES(option_text),
     option_value = VALUES(option_value),
     order_index = VALUES(order_index);

--- a/database.sql
+++ b/database.sql
@@ -102,6 +102,7 @@ CREATE TABLE IF NOT EXISTS response_answers (
     response_id INT UNSIGNED NOT NULL,
     question_id INT UNSIGNED NOT NULL,
     option_id INT UNSIGNED NULL,
+    type ENUM('multiple_choice','rating','text') NULL,
     answer_text TEXT NULL,
     numeric_value DECIMAL(10,4) NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -240,24 +241,25 @@ ON DUPLICATE KEY UPDATE
     participant_id = VALUES(participant_id),
     submitted_at = VALUES(submitted_at);
 
-INSERT INTO response_answers (id, response_id, question_id, option_id, answer_text, numeric_value, created_at) VALUES
-    (1, 1, 1, NULL, NULL, 4.0, '2025-03-07 10:15:00'),
-    (2, 1, 2, 1, NULL, NULL, '2025-03-07 10:15:00'),
-    (3, 1, 3, NULL, 'Uygulama envanteri icin rehber ve kontrol listesi istiyorum.', NULL, '2025-03-07 10:15:00'),
-    (4, 2, 1, NULL, NULL, 5.0, '2025-03-08 14:20:00'),
-    (5, 2, 2, 2, NULL, NULL, '2025-03-08 14:20:00'),
-    (6, 2, 3, NULL, 'Egitim kayitlarinin tekrarina hizli erisim ihtiyacim var.', NULL, '2025-03-08 14:20:00'),
-    (7, 3, 4, NULL, NULL, 4.0, '2024-11-18 16:45:00'),
-    (8, 3, 5, 4, NULL, NULL, '2024-11-18 16:45:00'),
-    (9, 3, 6, NULL, 'Simulasyon mailleri ile egitimler surdurulmeli.', NULL, '2024-11-18 16:45:00'),
-    (10, 4, 4, NULL, NULL, 3.0, '2024-11-20 09:30:00'),
-    (11, 4, 5, 6, NULL, NULL, '2024-11-20 09:30:00'),
-    (12, 4, 6, NULL, 'Ekip icinde hizli paylasim icin prosedur guncellenmeli.', NULL, '2024-11-20 09:30:00')
+INSERT INTO response_answers (id, response_id, question_id, option_id, type, answer_text, numeric_value, created_at) VALUES
+    (1, 1, 1, NULL, 'rating', NULL, 4.0, '2025-03-07 10:15:00'),
+    (2, 1, 2, 1, 'multiple_choice', NULL, NULL, '2025-03-07 10:15:00'),
+    (3, 1, 3, NULL, 'text', 'Uygulama envanteri icin rehber ve kontrol listesi istiyorum.', NULL, '2025-03-07 10:15:00'),
+    (4, 2, 1, NULL, 'rating', NULL, 5.0, '2025-03-08 14:20:00'),
+    (5, 2, 2, 2, 'multiple_choice', NULL, NULL, '2025-03-08 14:20:00'),
+    (6, 2, 3, NULL, 'text', 'Egitim kayitlarinin tekrarina hizli erisim ihtiyacim var.', NULL, '2025-03-08 14:20:00'),
+    (7, 3, 4, NULL, 'rating', NULL, 4.0, '2024-11-18 16:45:00'),
+    (8, 3, 5, 4, 'multiple_choice', NULL, NULL, '2024-11-18 16:45:00'),
+    (9, 3, 6, NULL, 'text', 'Simulasyon mailleri ile egitimler surdurulmeli.', NULL, '2024-11-18 16:45:00'),
+    (10, 4, 4, NULL, 'rating', NULL, 3.0, '2024-11-20 09:30:00'),
+    (11, 4, 5, 6, 'multiple_choice', NULL, NULL, '2024-11-20 09:30:00'),
+    (12, 4, 6, NULL, 'text', 'Ekip icinde hizli paylasim icin prosedur guncellenmeli.', NULL, '2024-11-20 09:30:00')
 
 ON DUPLICATE KEY UPDATE
     response_id = VALUES(response_id),
     question_id = VALUES(question_id),
     option_id = VALUES(option_id),
+    type = VALUES(type),
     answer_text = VALUES(answer_text),
     numeric_value = VALUES(numeric_value);
 

--- a/database.sql
+++ b/database.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS survey_questions (
     survey_id INT UNSIGNED NOT NULL,
     question_text TEXT NOT NULL,
     question_type ENUM('multiple_choice','rating','text') NOT NULL,
+    category_key VARCHAR(120) NULL,
     is_required TINYINT(1) NOT NULL DEFAULT 0,
     max_length INT NULL,
     order_index INT NOT NULL DEFAULT 0,

--- a/includes/services/SurveyService.php
+++ b/includes/services/SurveyService.php
@@ -130,6 +130,7 @@ class SurveyService
                 $surveyId,
                 $data['question_text'],
                 $data['question_type'],
+                $data['category_key'] ?? null,
                 !empty($data['is_required']) ? 1 : 0,
                 $data['max_length'] ?? null,
                 $data['order_index'] ?? 0,
@@ -151,6 +152,7 @@ class SurveyService
             [
                 $data['question_text'],
                 $data['question_type'],
+                $data['category_key'] ?? null,
                 !empty($data['is_required']) ? 1 : 0,
                 $data['max_length'] ?? null,
                 $data['order_index'] ?? 0,
@@ -318,6 +320,7 @@ class SurveyService
             $this->addQuestion($newSurveyId, [
                 'question_text' => $question['question_text'],
                 'question_type' => $question['question_type'],
+                'category_key' => $question['category_key'] ?? null,
                 'is_required' => $question['is_required'],
                 'max_length' => $question['max_length'],
                 'order_index' => $question['order_index'],

--- a/includes/services/SurveyService.php
+++ b/includes/services/SurveyService.php
@@ -193,7 +193,16 @@ class SurveyService
     public function getParticipants(int $surveyId): array
     {
         return $this->db->fetchAll(
-            'SELECT * FROM survey_participants WHERE survey_id = ? ORDER BY created_at DESC',
+            'SELECT sp.*, (
+                 SELECT sr.id
+                 FROM survey_responses sr
+                 WHERE sr.participant_id = sp.id
+                 ORDER BY sr.submitted_at DESC, sr.id DESC
+                 LIMIT 1
+             ) AS response_id
+             FROM survey_participants sp
+             WHERE sp.survey_id = ?
+             ORDER BY sp.created_at DESC',
             [$surveyId]
         );
     }

--- a/install.php
+++ b/install.php
@@ -117,6 +117,17 @@ SQL);
                 $logs[] = 'Mevcut sorular soru havuzuna kopyalandi.';
             }
         }
+
+        $responseAnswersExists = $pdo->query("SHOW TABLES LIKE 'response_answers'")->fetch();
+        if ($responseAnswersExists) {
+            $typeColumn = $pdo->query("SHOW COLUMNS FROM response_answers LIKE 'type'")->fetch();
+            if (!$typeColumn) {
+                $pdo->exec("ALTER TABLE response_answers ADD COLUMN type ENUM('multiple_choice','rating','text') NULL DEFAULT NULL AFTER option_id");
+                $logs[] = 'response_answers tablosuna type alani eklendi.';
+            } else {
+                $logs[] = 'response_answers tablosundaki type alani guncel.';
+            }
+        }
     } catch (Throwable $e) {
         $errors[] = 'Sema guncelleme hatasi: ' . $e->getMessage();
     }

--- a/install.php
+++ b/install.php
@@ -119,7 +119,24 @@ SQL);
         }
 
         $responseAnswersExists = $pdo->query("SHOW TABLES LIKE 'response_answers'")->fetch();
-        if ($responseAnswersExists) {
+        if (!$responseAnswersExists) {
+            $pdo->exec(<<<SQL
+CREATE TABLE response_answers (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    response_id INT UNSIGNED NOT NULL,
+    question_id INT UNSIGNED NOT NULL,
+    option_id INT UNSIGNED NULL,
+    type ENUM('multiple_choice','rating','text') NULL,
+    answer_text TEXT NULL,
+    numeric_value DECIMAL(10,4) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_answers_response FOREIGN KEY (response_id) REFERENCES survey_responses(id) ON DELETE CASCADE,
+    CONSTRAINT fk_answers_question FOREIGN KEY (question_id) REFERENCES survey_questions(id) ON DELETE CASCADE,
+    CONSTRAINT fk_answers_option FOREIGN KEY (option_id) REFERENCES question_options(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL);
+            $logs[] = 'response_answers tablosu olusturuldu.';
+        } else {
             $typeColumn = $pdo->query("SHOW COLUMNS FROM response_answers LIKE 'type'")->fetch();
             if (!$typeColumn) {
                 $pdo->exec("ALTER TABLE response_answers ADD COLUMN type ENUM('multiple_choice','rating','text') NULL DEFAULT NULL AFTER option_id");

--- a/participants.php
+++ b/participants.php
@@ -84,6 +84,7 @@ include __DIR__ . '/templates/navbar.php';
                         <th>Davet</th>
                         <th>Durum</th>
                         <th>Link</th>
+                        <th>Rapor</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -95,6 +96,13 @@ include __DIR__ . '/templates/navbar.php';
                             <td><?php echo $participant['invited_at'] ? h(format_date($participant['invited_at'], 'd.m.Y H:i')) : '-'; ?></td>
                             <td><?php echo $participant['responded_at'] ? '<span class="status status-active">Tamamlandi</span>' : '<span class="status status-draft">Bekliyor</span>'; ?></td>
                             <td><input type="text" readonly value="<?php echo h($link); ?>" onclick="this.select();"></td>
+                            <td>
+                                <?php if (!empty($participant['response_id'])): ?>
+                                    <a class="button-link" href="personal_report.php?response=<?php echo (int)$participant['response_id']; ?>">Raporu Gör</a>
+                                <?php else: ?>
+                                    -
+                                <?php endif; ?>
+                            </td>
                             <td>
                                 <a class="button-link" href="participants.php?id=<?php echo $surveyId; ?>&send=<?php echo (int)$participant['id']; ?>">E-posta Gonder</a>
                             </td>

--- a/participants.php
+++ b/participants.php
@@ -5,9 +5,11 @@ require_login();
 $surveyId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $survey = $surveyService->getSurvey($surveyId);
 if (!$survey) {
-    set_flash('danger', 'Anket bulunamadi.');
+    set_flash('danger', 'Anket bulunamadı.');
     redirect('surveys.php');
 }
+
+$pageTitle = 'Katılımcılar - ' . ($survey['title'] ?? config('app.name', 'Anketor'));
 
 if (isset($_GET['send'])) {
     $participantId = (int)$_GET['send'];
@@ -37,79 +39,121 @@ if (is_post()) {
             $added++;
         }
     }
-    set_flash('success', "$added katilimci eklendi.");
+    set_flash('success', "$added katılımcı eklendi.");
     redirect('participants.php?id=' . $surveyId);
 }
 
 $participants = $surveyService->getParticipants($surveyId);
+$totalParticipants = count($participants);
+$completed = 0;
+foreach ($participants as $participant) {
+    if (!empty($participant['responded_at'])) {
+        $completed++;
+    }
+}
+$pendingCount = $totalParticipants - $completed;
+$completionRate = $totalParticipants > 0 ? round(($completed / $totalParticipants) * 100) : 0;
 $flash = get_flash();
 include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
 ?>
 <main class="container">
-    <div class="panel-header">
-        <h1>Katilimcilar &raquo; <?php echo h($survey['title']); ?></h1>
-        <a class="button-secondary" href="survey_questions.php?id=<?php echo $surveyId; ?>">Sorular</a>
-    </div>
+    <header class="page-header">
+        <div>
+            <p class="eyebrow">Katılımcılar</p>
+            <h1><?php echo h($survey['title']); ?></h1>
+            <p class="page-subtitle">Anket bağlantısını paylaşın, davetleri takip edin ve kişisel raporları tek noktadan yönetin.</p>
+        </div>
+        <div class="page-header__actions">
+            <a class="button-secondary" href="survey_questions.php?id=<?php echo $surveyId; ?>">Sorular</a>
+            <a class="button-secondary" href="survey_reports.php?id=<?php echo $surveyId; ?>">Raporlar</a>
+        </div>
+    </header>
 
     <?php if ($flash): ?>
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
     <?php endif; ?>
 
+    <section class="stats-grid">
+        <div class="stat-card">
+            <span class="stat-label">Toplam Davet</span>
+            <span class="stat-value"><?php echo $totalParticipants; ?></span>
+        </div>
+        <div class="stat-card">
+            <span class="stat-label">Tamamlanan</span>
+            <span class="stat-value"><?php echo $completed; ?></span>
+        </div>
+        <div class="stat-card">
+            <span class="stat-label">Bekleyen</span>
+            <span class="stat-value"><?php echo $pendingCount; ?></span>
+        </div>
+        <div class="stat-card">
+            <span class="stat-label">Tamamlanma Oranı</span>
+            <span class="stat-value"><?php echo $totalParticipants ? $completionRate . '%': 'N/A'; ?></span>
+        </div>
+    </section>
+
     <section class="panel">
         <div class="panel-header">
-            <h2>Katilimci Ekle</h2>
+            <h2>Yeni Katılımcı Ekle</h2>
         </div>
         <div class="panel-body">
             <form method="POST">
                 <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
                 <div class="form-group">
                     <label for="emails">E-posta adresleri</label>
-                    <textarea id="emails" name="emails" rows="4" placeholder="her satira bir e-posta"></textarea>
+                    <textarea id="emails" name="emails" rows="4" placeholder="Her satıra bir e-posta yazın"></textarea>
+                    <small class="help-text">Eklenen katılımcılar otomatik olarak benzersiz link alır. Dilerseniz bağlantıları aşağıdaki listeden kopyalayabilirsiniz.</small>
                 </div>
-                <button type="submit" class="button-primary">Katilimcilari Kaydet</button>
+                <div class="form-actions">
+                    <button type="submit" class="button-primary">Katılımcıları Kaydet</button>
+                </div>
             </form>
         </div>
     </section>
 
     <section class="panel">
         <div class="panel-header">
-            <h2>Liste</h2>
+            <h2>Kayıtlı Katılımcılar</h2>
         </div>
         <div class="panel-body">
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th>E-posta</th>
-                        <th>Davet</th>
-                        <th>Durum</th>
-                        <th>Link</th>
-                        <th>Rapor</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($participants as $participant): ?>
-                        <?php $link = base_url('answer.php?id=' . $surveyId . '&token=' . urlencode($participant['token'])); ?>
+            <?php if (empty($participants)): ?>
+                <p>Henüz davet gönderilmedi. Listeniz burada görünecek.</p>
+            <?php else: ?>
+                <table class="table">
+                    <thead>
                         <tr>
-                            <td><?php echo h($participant['email']); ?></td>
-                            <td><?php echo $participant['invited_at'] ? h(format_date($participant['invited_at'], 'd.m.Y H:i')) : '-'; ?></td>
-                            <td><?php echo $participant['responded_at'] ? '<span class="status status-active">Tamamlandi</span>' : '<span class="status status-draft">Bekliyor</span>'; ?></td>
-                            <td><input type="text" readonly value="<?php echo h($link); ?>" onclick="this.select();"></td>
-                            <td>
-                                <?php if (!empty($participant['response_id'])): ?>
-                                    <a class="button-link" href="personal_report.php?response=<?php echo (int)$participant['response_id']; ?>">Raporu Gör</a>
-                                <?php else: ?>
-                                    -
-                                <?php endif; ?>
-                            </td>
-                            <td>
-                                <a class="button-link" href="participants.php?id=<?php echo $surveyId; ?>&send=<?php echo (int)$participant['id']; ?>">E-posta Gonder</a>
-                            </td>
+                            <th>E-posta</th>
+                            <th>Davet</th>
+                            <th>Durum</th>
+                            <th>Link</th>
+                            <th>Rapor</th>
+                            <th></th>
                         </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($participants as $participant): ?>
+                            <?php $link = base_url('answer.php?id=' . $surveyId . '&token=' . urlencode($participant['token'])); ?>
+                            <tr>
+                                <td><?php echo h($participant['email']); ?></td>
+                                <td><?php echo $participant['invited_at'] ? h(format_date($participant['invited_at'], 'd.m.Y H:i')) : '-'; ?></td>
+                                <td><?php echo $participant['responded_at'] ? '<span class="status status-active">Tamamlandı</span>' : '<span class="status status-draft">Bekliyor</span>'; ?></td>
+                                <td><input type="text" readonly value="<?php echo h($link); ?>" onclick="this.select();"></td>
+                                <td>
+                                    <?php if (!empty($participant['response_id'])): ?>
+                                        <a class="button-link" href="personal_report.php?response=<?php echo (int)$participant['response_id']; ?>">Raporu Gör</a>
+                                    <?php else: ?>
+                                        -
+                                    <?php endif; ?>
+                                </td>
+                                <td>
+                                    <a class="button-link" href="participants.php?id=<?php echo $surveyId; ?>&send=<?php echo (int)$participant['id']; ?>">E-posta Gönder</a>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php endif; ?>
         </div>
     </section>
 </main>

--- a/personal_report.php
+++ b/personal_report.php
@@ -6,13 +6,13 @@ $token = $_GET['token'] ?? null;
 
 if ($responseId <= 0) {
     http_response_code(404);
-    exit('Rapor bulunamadý.');
+    exit('Rapor bulunamadÄ±.');
 }
 
 $report = $surveyService->generatePersonalReport($responseId);
 if (!$report) {
     http_response_code(404);
-    exit('Rapor bulunamadý.');
+    exit('Rapor bulunamadÄ±.');
 }
 
 $participantInfo = $report['participant'] ?? [];
@@ -30,7 +30,7 @@ if (current_user_id()) {
 
 if (!$allowed) {
     http_response_code(403);
-    exit('Bu rapora eriþim yetkiniz yok.');
+    exit('Bu rapora eriÅŸim yetkiniz yok.');
 }
 
 if (!empty($_SESSION['personal_report_response']) && (int)$_SESSION['personal_report_response'] === $responseId) {
@@ -42,6 +42,7 @@ $averageScore = $report['overview']['average_score'] ?? null;
 $strengths = $report['overview']['strengths'] ?? [];
 $gaps = $report['overview']['gaps'] ?? [];
 $advice = $report['advice'] ?? '';
+$manualSuggestions = $report['manual_suggestions'] ?? [];
 
 include __DIR__ . '/templates/header.php';
 if (current_user_id()) {
@@ -51,14 +52,14 @@ if (current_user_id()) {
 <main class="container personal-report">
     <section class="panel">
         <div class="panel-header">
-            <h1>Kiþisel Güvenlik Raporu</h1>
+            <h1>KiÅŸisel GÃ¼venlik Raporu</h1>
             <?php if ($submittedAt): ?>
                 <span class="badge badge-time"><?php echo h(format_date($submittedAt, 'd.m.Y H:i')); ?></span>
             <?php endif; ?>
         </div>
         <div class="panel-body">
             <?php if (!empty($participantInfo['email'])): ?>
-                <p class="report-subtitle">Sayýn <?php echo h($participantInfo['email']); ?>, verdiðiniz yanýtlarýn kýsa özeti:</p>
+                <p class="report-subtitle">SayÄ±n <?php echo h($participantInfo['email']); ?>, verdiÄŸiniz yanÄ±tlarÄ±n kÄ±sa Ã¶zeti:</p>
             <?php endif; ?>
             <div class="report-overview">
                 <div class="overview-item">
@@ -66,11 +67,11 @@ if (current_user_id()) {
                     <span class="value"><?php echo $averageScore !== null ? h($averageScore) : ' - '; ?></span>
                 </div>
                 <div class="overview-item">
-                    <span class="label">Güçlü Alanlar</span>
-                    <span class="value"><?php echo $strengths ? h(implode(', ', $strengths)) : 'Henüz belirlenmedi'; ?></span>
+                    <span class="label">GÃ¼Ã§lÃ¼ Alanlar</span>
+                    <span class="value"><?php echo $strengths ? h(implode(', ', $strengths)) : 'HenÃ¼z belirlenmedi'; ?></span>
                 </div>
                 <div class="overview-item">
-                    <span class="label">Geliþim Alanlarý</span>
+                    <span class="label">GeliÅŸim AlanlarÄ±</span>
                     <span class="value"><?php echo $gaps ? h(implode(', ', $gaps)) : 'Belirlenmedi'; ?></span>
                 </div>
             </div>
@@ -109,7 +110,7 @@ if (current_user_id()) {
     <?php if (!empty($advice)): ?>
         <section class="panel">
             <div class="panel-header">
-                <h2>Önerilen Aksiyon Planý</h2>
+                <h2>Ã–nerilen Aksiyon PlanÄ±</h2>
             </div>
             <div class="panel-body">
                 <p class="advice-text"><?php echo nl2br(h($advice)); ?></p>
@@ -117,9 +118,27 @@ if (current_user_id()) {
         </section>
     <?php endif; ?>
 
+    <?php if (!empty($manualSuggestions)): ?>
+        <section class="panel">
+            <div class="panel-header">
+                <h2>Uzman NotlarÄ±</h2>
+            </div>
+            <div class="panel-body">
+                <ul class="knowledge-list">
+                    <?php foreach ($manualSuggestions as $item): ?>
+                        <li class="knowledge-item">
+                            <strong><?php echo h($item['prompt'] ?: 'Ã–neri'); ?></strong>
+                            <p><?php echo nl2br(h($item['suggestion'])); ?></p>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        </section>
+    <?php endif; ?>
+
     <section class="panel">
         <div class="panel-body report-actions">
-            <a class="button-secondary" href="thank_you.php">Dönüþ Yap</a>
+            <a class="button-secondary" href="thank_you.php">DÃ¶nÃ¼ÅŸ Yap</a>
             <?php if (current_user_id()): ?>
                 <a class="button-secondary" href="survey_reports.php?id=<?php echo (int)$report['survey']['id']; ?>">Anket Raporuna Git</a>
             <?php endif; ?>

--- a/reports.php
+++ b/reports.php
@@ -18,14 +18,19 @@ $recentReports = $db->fetchAll(
      LIMIT 5'
 );
 
+$pageTitle = 'Raporlar - ' . config('app.name', 'Anketor');
 $flash = get_flash();
 include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
 ?>
 <main class="container">
-    <div class="panel-header">
-        <h1>Genel Raporlar</h1>
-    </div>
+    <header class="page-header">
+        <div>
+            <p class="eyebrow">Analitik</p>
+            <h1>Genel Raporlar</h1>
+            <p class="page-subtitle">Anket performansını, trendleri ve akıllı rapor çıktılarınızı tek ekranda izleyin.</p>
+        </div>
+    </header>
 
     <?php if ($flash): ?>
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
@@ -33,15 +38,15 @@ include __DIR__ . '/templates/navbar.php';
 
     <section class="panel">
         <div class="panel-header">
-            <h2>Anket Performansi</h2>
+            <h2>Anket Performansı</h2>
         </div>
         <div class="panel-body">
             <table class="table">
                 <thead>
                     <tr>
-                        <th>Baslik</th>
+                        <th>Başlık</th>
                         <th>Durum</th>
-                        <th>Donem</th>
+                        <th>Dönem</th>
                         <th>Cevap</th>
                         <th></th>
                     </tr>
@@ -66,7 +71,7 @@ include __DIR__ . '/templates/navbar.php';
 
     <section class="panel">
         <div class="panel-header">
-            <h2>Son Akilli Raporlar</h2>
+            <h2>Son Akıllı Raporlar</h2>
         </div>
         <div class="panel-body">
             <?php if ($recentReports): ?>
@@ -83,7 +88,7 @@ include __DIR__ . '/templates/navbar.php';
                     <?php endforeach; ?>
                 </ul>
             <?php else: ?>
-                <p>Henuz rapor olusturulmadi.</p>
+                <p>Henüz rapor oluşturulmadı.</p>
             <?php endif; ?>
         </div>
     </section>

--- a/survey_question_edit.php
+++ b/survey_question_edit.php
@@ -28,6 +28,7 @@ if (is_post()) {
     $surveyService->updateQuestion($questionId, [
         'question_text' => trim($_POST['question_text'] ?? ''),
         'question_type' => $type,
+        'category_key' => ($categoryKey = trim($_POST['category_key'] ?? '')) !== '' ? $categoryKey : null,
         'is_required' => !empty($_POST['is_required']),
         'max_length' => $type === 'text' ? (int)($_POST['max_length'] ?? 0) : null,
         'order_index' => (int)($_POST['order_index'] ?? 0),

--- a/survey_questions.php
+++ b/survey_questions.php
@@ -38,6 +38,7 @@ if (is_post()) {
         $surveyService->addQuestion($surveyId, [
             'question_text' => trim($_POST['question_text'] ?? ''),
             'question_type' => $type,
+            'category_key' => ($categoryKey = trim($_POST['category_key'] ?? '')) !== '' ? $categoryKey : null,
             'is_required' => !empty($_POST['is_required']),
             'max_length' => $type === 'text' ? (int)($_POST['max_length'] ?? 0) : null,
             'order_index' => (int)($_POST['order_index'] ?? 0),

--- a/survey_questions.php
+++ b/survey_questions.php
@@ -8,6 +8,7 @@ if (!$survey) {
     set_flash('danger', 'Anket bulunamadi.');
     redirect('surveys.php');
 }
+$pageTitle = 'Sorular - ' . ($survey['title'] ?? config('app.name', 'Anketor'));
 
 if (isset($_GET['delete_question'])) {
     $questionId = (int)$_GET['delete_question'];
@@ -35,7 +36,7 @@ if (is_post()) {
 
         try {
             $surveyService->addQuestionFromLibrary($surveyId, $libraryQuestionId, $orderIndex);
-            set_flash('success', 'Hazir soru ankete eklendi.');
+            set_flash('success', 'Hazır soru ankete eklendi.');
         } catch (InvalidArgumentException $e) {
             set_flash('danger', $e->getMessage());
         }
@@ -99,14 +100,18 @@ include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
 ?>
 <main class="container">
-    <div class="panel-header">
-        <h1>Sorular &raquo; <?php echo h($survey['title']); ?></h1>
-        <div class="inline-actions">
-            <a class="button-secondary" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Ayarlar</a>
-            <a class="button-secondary" href="participants.php?id=<?php echo (int)$survey['id']; ?>">Katilimcilar</a>
-            <a class="button-primary" href="answer_preview.php?id=<?php echo (int)$survey['id']; ?>" target="_blank">Anketi Gor</a>
+    <header class="page-header">
+        <div>
+            <p class="eyebrow">Soru Tasarımı</p>
+            <h1><?php echo h($survey['title']); ?></h1>
+            <p class="page-subtitle">Hazır soru havuzundan seçim yapın veya yeni sorular oluşturup AI önerileriyle zenginleştirin.</p>
         </div>
-    </div>
+        <div class="page-header__actions">
+            <a class="button-secondary" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Ayarlar</a>
+            <a class="button-secondary" href="participants.php?id=<?php echo (int)$survey['id']; ?>">Katılımcılar</a>
+            <a class="button-primary" href="answer_preview.php?id=<?php echo (int)$survey['id']; ?>" target="_blank">Anketi Gör</a>
+        </div>
+    </header>
 
     <?php if ($flash): ?>
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
@@ -114,19 +119,19 @@ include __DIR__ . '/templates/navbar.php';
 
     <section class="panel">
         <div class="panel-header">
-            <h2>Hazir Sorudan Ekle</h2>
+            <h2>Hazır Sorudan Ekle</h2>
         </div>
         <div class="panel-body">
             <?php if (empty($libraryQuestions)): ?>
-                <p>Henuz soru havuzunda kayit bulunmuyor. Yeni sorular olustururken "Soru havuzuna ekle" secenegini kullanabilirsiniz.</p>
+                <p>Henüz soru havuzunda kayıt bulunmuyor. Yeni sorular oluştururken "Soru havuzuna ekle" seçeneğini kullanabilirsiniz.</p>
             <?php else: ?>
                 <form method="POST" class="form-horizontal">
                     <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
                     <input type="hidden" name="action" value="add_from_library">
                     <div class="form-group">
-                        <label for="library_question_id">Hazir Soru</label>
+                        <label for="library_question_id">Hazır Soru</label>
                         <select id="library_question_id" name="library_question_id" required>
-                            <option value="">Bir soru secin</option>
+                            <option value="">Bir soru seçin</option>
                             <?php foreach ($libraryByCategory as $group => $items): ?>
                                 <optgroup label="<?php echo h(str_replace('_', ' ', ucfirst($group))); ?>">
                                     <?php foreach ($items as $item): ?>
@@ -145,11 +150,11 @@ include __DIR__ . '/templates/navbar.php';
                         </select>
                     </div>
                     <div class="form-group">
-                        <label for="library_order_index">Sirasi</label>
+                        <label for="library_order_index">Sırası</label>
                         <input type="number" id="library_order_index" name="order_index" value="<?php echo count($questions); ?>" min="0">
                     </div>
                     <div class="form-actions">
-                        <button type="submit" class="button-primary">Hazir Soruyu Ekle</button>
+                        <button type="submit" class="button-primary">Hazır Soruyu Ekle</button>
                     </div>
                 </form>
             <?php endif; ?>
@@ -172,18 +177,18 @@ include __DIR__ . '/templates/navbar.php';
                     <div class="form-group">
                         <label for="question_type">Soru Tipi</label>
                         <select id="question_type" name="question_type">
-                            <option value="multiple_choice">Coktan Secmeli</option>
+                            <option value="multiple_choice">Çoktan Seçmeli</option>
                             <option value="rating">1-5 Dereceleme</option>
-                            <option value="text">Acik Uclu</option>
+                            <option value="text">Açık Uçlu</option>
                         </select>
                     </div>
                     <div class="form-group">
-                        <label for="category_key">Kategori Anahtari</label>
+                        <label for="category_key">Kategori Anahtarı</label>
                         <input type="text" id="category_key" name="category_key" placeholder="web_guvenligi">
-                        <small class="help-text">Raporlamada kullanilacak kisa anahtar. Orn: web_guvenligi</small>
+                        <small class="help-text">Raporlamada kullanılacak kısa anahtar. Örn: web_guvenligi</small>
                     </div>
                     <div class="form-group">
-                        <label for="order_index">Sirasi</label>
+                        <label for="order_index">Sırası</label>
                         <input type="number" id="order_index" name="order_index" value="<?php echo count($questions); ?>" min="0">
                     </div>
                     <div class="form-group">
@@ -203,9 +208,9 @@ include __DIR__ . '/templates/navbar.php';
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="options">Secenekler (her satira bir)</label>
+                    <label for="options">Seçenekler (her satıra bir)</label>
                     <textarea id="options" name="options" rows="4" placeholder="Evet\nHayir\nKismi"></textarea>
-                    <small class="help-text">Yalnizca coktan secmeli sorular icin kullanilir.</small>
+                    <small class="help-text">Yalnızca coktan secmeli sorular icin kullanilir.</small>
                 </div>
                 <div class="form-actions">
                     <button type="submit" class="button-primary">Soru Ekle</button>
@@ -216,7 +221,7 @@ include __DIR__ . '/templates/navbar.php';
 
     <section class="panel">
         <div class="panel-header">
-            <h2>AI Soru Onerisi</h2>
+            <h2>AI Soru Önerisi</h2>
         </div>
         <div class="panel-body">
             <form method="POST" class="inline-form">
@@ -224,14 +229,14 @@ include __DIR__ . '/templates/navbar.php';
                 <input type="hidden" name="action" value="ai_suggest">
                 <label for="topic">Tema</label>
                 <input type="text" id="topic" name="topic" placeholder="Orn: Calisan bagliligi" required>
-                <button type="submit" class="button-secondary">Oneri Al</button>
+                <button type="submit" class="button-secondary">Öneri Al</button>
                 <?php if (!$surveyService->aiClient()->isEnabled()): ?>
                     <span class="tag">Demo modu</span>
                 <?php endif; ?>
             </form>
             <?php if (!empty($aiSuggestions)): ?>
                 <div class="suggestions">
-                    <h3>Onerilen sorular</h3>
+                    <h3>Önerilen sorular</h3>
                     <ul>
                         <?php foreach ($aiSuggestions as $suggestion): ?>
                             <li>
@@ -257,7 +262,7 @@ include __DIR__ . '/templates/navbar.php';
         </div>
         <div class="panel-body">
             <?php if (empty($questions)): ?>
-                <p>Bu ankette henuz soru yok.</p>
+                <p>Bu ankette henüz soru yok.</p>
             <?php else: ?>
                 <ul class="question-list">
                     <?php foreach ($questions as $question): ?>

--- a/surveys.php
+++ b/surveys.php
@@ -3,54 +3,83 @@ require __DIR__ . '/includes/bootstrap.php';
 require_login();
 
 $surveys = $surveyService->getSurveys(200);
+$pageTitle = 'Anketler - ' . config('app.name', 'Anketor');
 $flash = get_flash();
 include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
 ?>
 <main class="container">
-    <div class="panel-header">
-        <h1>Anketler</h1>
-        <a class="button-primary" href="survey_edit.php">Yeni Anket</a>
-    </div>
+    <header class="page-header">
+        <div>
+            <p class="eyebrow">Anketler</p>
+            <h1>Stratejik Anketler</h1>
+            <p class="page-subtitle"><?php echo count($surveys); ?> kayıtlı anket ile organizasyon güvenliğini ölçün.</p>
+        </div>
+        <div class="page-header__actions">
+            <a class="button-primary" href="survey_edit.php">Yeni Anket</a>
+            <a class="button-secondary" href="dashboard.php">Gösterge Paneli</a>
+        </div>
+    </header>
 
     <?php if ($flash): ?>
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
     <?php endif; ?>
 
-    <div class="panel-body">
-        <table class="table">
-            <thead>
-                <tr>
-                    <th>Baslik</th>
-                    <th>Durum</th>
-                    <th>Donem</th>
-                    <th>Olusturan</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($surveys as $survey): ?>
-                    <tr>
-                        <td><?php echo h($survey['title']); ?></td>
-                        <td><span class="status status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span></td>
-                        <td>
-                            <?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?>
-                            <?php if ($survey['end_date']): ?>
-                                &ndash; <?php echo h(format_date($survey['end_date'])); ?>
-                            <?php endif; ?>
-                        </td>
-                        <td><?php echo h($survey['created_by']); ?></td>
-                        <td class="table-actions">
-                            <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Duzenle</a>
-                            <a class="button-link" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Sorular</a>
-                            <a class="button-link" href="participants.php?id=<?php echo (int)$survey['id']; ?>">Katilimcilar</a>
-                            <a class="button-link" href="survey_reports.php?id=<?php echo (int)$survey['id']; ?>">Rapor</a>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    </div>
+    <?php if (empty($surveys)): ?>
+        <section class="empty-state">
+            <h2>Henüz anket oluşturulmadı</h2>
+            <p>Hazır soru havuzunu kullanarak dakikalar içinde ilk anketinizi yayınlayabilirsiniz.</p>
+            <a class="button-primary" href="survey_edit.php">İlk anketi oluştur</a>
+        </section>
+    <?php else: ?>
+        <section class="survey-grid">
+            <?php foreach ($surveys as $survey): ?>
+                <?php
+                $period = $survey['start_date'] ? format_date($survey['start_date']) : '-';
+                if (!empty($survey['end_date'])) {
+                    $period .= ' – ' . format_date($survey['end_date']);
+                }
+                $description = $survey['description'] ?? '';
+                if ($description) {
+                    if (function_exists('mb_strimwidth')) {
+                        $description = mb_strimwidth($description, 0, 140, '...');
+                    } elseif (strlen($description) > 140) {
+                        $description = substr($description, 0, 137) . '...';
+                    }
+                }
+                ?>
+                <article class="survey-card">
+                    <header class="survey-card__header">
+                        <span class="status status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
+                        <h2><?php echo h($survey['title']); ?></h2>
+                        <?php if ($description): ?>
+                            <p><?php echo h($description); ?></p>
+                        <?php endif; ?>
+                    </header>
+                    <dl class="survey-meta">
+                        <div>
+                            <dt>Dönem</dt>
+                            <dd><?php echo h($period); ?></dd>
+                        </div>
+                        <div>
+                            <dt>Kategori</dt>
+                            <dd><?php echo h($survey['category_name'] ?? '-'); ?></dd>
+                        </div>
+                        <div>
+                            <dt>Sahip</dt>
+                            <dd><?php echo h($survey['owner_name'] ?? '-'); ?></dd>
+                        </div>
+                    </dl>
+                    <div class="survey-card__actions">
+                        <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Sorular</a>
+                        <a class="button-secondary" href="participants.php?id=<?php echo (int)$survey['id']; ?>">Katılımcılar</a>
+                        <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Ayarlar</a>
+                        <a class="button-link" href="survey_reports.php?id=<?php echo (int)$survey['id']; ?>">Rapor</a>
+                    </div>
+                </article>
+            <?php endforeach; ?>
+        </section>
+    <?php endif; ?>
 </main>
 <?php include __DIR__ . '/templates/footer.php'; ?>
 

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,5 +1,6 @@
 <footer class="site-footer">
-    <p>&copy; <?php echo date('Y'); ?> <?php echo h(config('app.name', 'Anketor')); ?>. Tum haklari saklidir.</p>
+    <p>&copy; <?php echo date('Y'); ?> <?php echo h(config('app.name', 'Anketor')); ?>. Tüm hakları saklıdır.</p>
+    <p class="help-text">Katılımcı odaklı içgörüler üretmek için tasarlandı.</p>
 </footer>
 <script src="<?php echo asset_url('js/app.js'); ?>"></script>
 </body>

--- a/templates/header.php
+++ b/templates/header.php
@@ -1,11 +1,14 @@
 <?php
 $flash = $flash ?? get_flash();
+$pageTitle = $pageTitle ?? config('app.name', 'Anketor');
 ?><!DOCTYPE html>
 <html lang="tr">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo h(config('app.name', 'Anketor')); ?></title>
+    <meta name="description" content="Anketor ile modern anketler oluşturun, katılımcı yanıtlarını analiz edin ve kişisel raporlar üretin.">
+    <meta name="color-scheme" content="light">
+    <title><?php echo h($pageTitle); ?></title>
     <link rel="stylesheet" href="<?php echo asset_url('css/style.css'); ?>">
 </head>
-<body>
+<body class="app-body">

--- a/templates/navbar.php
+++ b/templates/navbar.php
@@ -5,10 +5,11 @@
         <li><a class="<?php echo active_nav('dashboard.php'); ?>" href="dashboard.php">Ana Sayfa</a></li>
         <li><a class="<?php echo active_nav('surveys.php'); ?>" href="surveys.php">Anketler</a></li>
         <li><a class="<?php echo active_nav('reports.php'); ?>" href="reports.php">Raporlar</a></li>
+        <li><a class="<?php echo active_nav('users.php'); ?>" href="users.php">Kullanıcılar</a></li>
     </ul>
     <div class="user-meta">
         <span><?php echo h(current_user_name()); ?></span>
-        <a class="button-secondary" href="logout.php">Cikis</a>
+        <a class="button-secondary" href="logout.php">Çıkış</a>
     </div>
 </nav>
 <?php endif; ?>

--- a/users.php
+++ b/users.php
@@ -1,0 +1,124 @@
+<?php
+require __DIR__ . '/includes/bootstrap.php';
+require_login();
+
+$pageTitle = 'Kullanıcılar - ' . config('app.name', 'Anketor');
+$errors = [];
+
+if (is_post()) {
+    guard_csrf();
+    $name = trim($_POST['name'] ?? '');
+    $email = trim(strtolower($_POST['email'] ?? ''));
+    $password = $_POST['password'] ?? '';
+
+    if ($name === '') {
+        $errors[] = 'İsim alanı boş olamaz.';
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Geçerli bir e-posta adresi girin.';
+    }
+
+    if (strlen($password) < 8) {
+        $errors[] = 'Parola en az 8 karakter olmalı.';
+    }
+
+    if (empty($errors)) {
+        $exists = $db->fetch('SELECT id FROM users WHERE email = ?', [$email]);
+        if ($exists) {
+            $errors[] = 'Bu e-posta için zaten kayıt var.';
+        } else {
+            $hash = password_hash($password, PASSWORD_BCRYPT);
+            $db->insert(
+                'INSERT INTO users (name, email, password_hash) VALUES (?, ?, ?)',
+                [$name, $email, $hash]
+            );
+            set_flash('success', 'Yeni kullanıcı eklendi.');
+            redirect('users.php');
+        }
+    }
+}
+
+$users = $db->fetchAll('SELECT id, name, email, last_login_at, created_at FROM users ORDER BY created_at DESC');
+$flash = get_flash();
+include __DIR__ . '/templates/header.php';
+include __DIR__ . '/templates/navbar.php';
+?>
+<main class="container">
+    <header class="page-header">
+        <div>
+            <p class="eyebrow">Takım</p>
+            <h1>Kayıtlı Kullanıcılar</h1>
+            <p class="page-subtitle">Yönetim paneline erişimi olan ekip üyelerini buradan yönetin.</p>
+        </div>
+    </header>
+
+    <?php if ($flash): ?>
+        <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
+    <?php endif; ?>
+
+    <?php if (!empty($errors)): ?>
+        <div class="alert alert-danger">
+            <?php foreach ($errors as $error): ?>
+                <div><?php echo h($error); ?></div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <section class="panel">
+        <div class="panel-header">
+            <h2>Yeni Kullanıcı</h2>
+        </div>
+        <div class="panel-body">
+            <form method="POST" class="form-grid">
+                <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+                <div class="form-group">
+                    <label for="name">İsim Soyisim</label>
+                    <input type="text" id="name" name="name" required value="<?php echo h($_POST['name'] ?? ''); ?>">
+                </div>
+                <div class="form-group">
+                    <label for="email">E-posta</label>
+                    <input type="email" id="email" name="email" required value="<?php echo h($_POST['email'] ?? ''); ?>">
+                </div>
+                <div class="form-group">
+                    <label for="password">Parola</label>
+                    <input type="password" id="password" name="password" required placeholder="En az 8 karakter">
+                </div>
+                <div class="form-actions">
+                    <button type="submit" class="button-primary">Kullanıcı Ekle</button>
+                </div>
+            </form>
+        </div>
+    </section>
+
+    <section class="panel">
+        <div class="panel-header">
+            <h2>Mevcut Kullanıcılar</h2>
+        </div>
+        <div class="panel-body">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>İsim</th>
+                        <th>E-posta</th>
+                        <th>Son Giriş</th>
+                        <th>Kayıt Tarihi</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($users as $user): ?>
+                        <tr>
+                            <td><?php echo (int)$user['id']; ?></td>
+                            <td><?php echo h($user['name']); ?></td>
+                            <td><?php echo h($user['email']); ?></td>
+                            <td><?php echo $user['last_login_at'] ? h(format_date($user['last_login_at'], 'd.m.Y H:i')) : '-'; ?></td>
+                            <td><?php echo $user['created_at'] ? h(format_date($user['created_at'], 'd.m.Y')) : '-'; ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </section>
+</main>
+<?php include __DIR__ . '/templates/footer.php'; ?>


### PR DESCRIPTION
## Summary
- ensure new survey questions persist their category keys for reporting
- keep updates and duplicates aligned with category-driven personal reports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f054da14832ebcd39305a24c7ded