### PR TITLE
Revamp surveys page layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1635,3 +1635,524 @@ textarea {
     bottom: 1.5rem;
     background: linear-gradient(180deg, rgba(245, 246, 251, 0), rgba(245, 246, 251, 0.95));
 }
+
+/* Dashboard refresh */
+.dashboard {
+    max-width: 1200px;
+    margin: clamp(1.5rem, 5vw, 3.5rem) auto 4rem;
+    padding: 0 clamp(1.25rem, 4vw, 2.75rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(2rem, 4vw, 3rem);
+}
+
+.dashboard-hero {
+    position: relative;
+    border-radius: 28px;
+    padding: clamp(2rem, 4vw, 3.25rem);
+    background: radial-gradient(circle at top left, rgba(60, 109, 240, 0.18), transparent 45%),
+        radial-gradient(circle at bottom right, rgba(35, 197, 255, 0.16), transparent 55%),
+        linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(247, 250, 255, 0.9));
+    box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+    overflow: hidden;
+}
+
+.dashboard-hero::after {
+    content: '';
+    position: absolute;
+    inset: 12% -30% -40% auto;
+    width: 360px;
+    height: 360px;
+    background: radial-gradient(circle, rgba(60, 109, 240, 0.35), transparent 65%);
+    filter: blur(6px);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.dashboard-hero__inner {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+    gap: clamp(2rem, 4vw, 3rem);
+    align-items: start;
+}
+
+.dashboard-hero__intro {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    position: relative;
+    z-index: 1;
+}
+
+.dashboard-hero__eyebrow {
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(17, 24, 39, 0.6);
+    font-weight: 600;
+}
+
+.dashboard-hero__intro h1 {
+    margin: 0;
+    font-size: clamp(2.1rem, 4vw, 2.9rem);
+    color: #0f172a;
+}
+
+.dashboard-hero__lead {
+    margin: 0;
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: rgba(15, 23, 42, 0.72);
+    max-width: 540px;
+}
+
+.dashboard-hero__stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.hero-chip {
+    background: rgba(255, 255, 255, 0.75);
+    border-radius: 16px;
+    padding: 1rem 1.25rem;
+    box-shadow: 0 18px 40px rgba(60, 109, 240, 0.12);
+    display: grid;
+    gap: 0.45rem;
+    min-width: 200px;
+}
+
+.hero-chip__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(15, 23, 42, 0.55);
+    font-weight: 600;
+}
+
+.hero-chip__value {
+    font-size: 1.55rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.hero-chip__meta {
+    font-size: 0.85rem;
+    color: rgba(15, 23, 42, 0.65);
+}
+
+.hero-chip__progress {
+    position: relative;
+    display: block;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(60, 109, 240, 0.15);
+    overflow: hidden;
+}
+
+.hero-chip__progress span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--color-primary), #5a8df4);
+}
+
+.dashboard-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.dashboard-hero__aside {
+    display: grid;
+    gap: 1.5rem;
+    position: relative;
+    z-index: 1;
+}
+
+.ai-summary {
+    background: rgba(15, 23, 42, 0.9);
+    color: #f8fafc;
+    border-radius: 22px;
+    padding: 1.5rem 1.75rem 1.75rem;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.35);
+}
+
+.ai-summary::before {
+    content: '';
+    position: absolute;
+    inset: -40% auto auto -30%;
+    width: 280px;
+    height: 280px;
+    background: radial-gradient(circle, rgba(59, 130, 246, 0.65), transparent 65%);
+    opacity: 0.5;
+}
+
+.ai-summary__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    background: rgba(248, 250, 252, 0.12);
+    backdrop-filter: blur(6px);
+    font-weight: 700;
+    margin-bottom: 1rem;
+}
+
+.ai-summary__body {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 1rem;
+}
+
+.ai-summary__body h3 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.ai-summary__list {
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.ai-summary__list div {
+    display: grid;
+    gap: 0.2rem;
+}
+
+.ai-summary__list dt {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(248, 250, 252, 0.68);
+}
+
+.ai-summary__list dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.ai-summary__action {
+    align-self: flex-start;
+}
+
+.ai-summary__hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(248, 250, 252, 0.7);
+}
+
+.spotlight-card {
+    background: rgba(255, 255, 255, 0.88);
+    border-radius: 20px;
+    padding: 1.5rem 1.75rem;
+    box-shadow: 0 22px 40px rgba(15, 23, 42, 0.12);
+    display: grid;
+    gap: 1rem;
+}
+
+.spotlight-card__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(15, 23, 42, 0.5);
+}
+
+.spotlight-card h3 {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.spotlight-card__meta {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+}
+
+.spotlight-card__meta strong {
+    font-weight: 600;
+}
+
+.spotlight-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: capitalize;
+    background: rgba(99, 102, 241, 0.12);
+    color: var(--color-primary);
+}
+
+.status-pill.status-draft {
+    background: rgba(148, 163, 184, 0.16);
+    color: rgba(71, 85, 105, 0.95);
+}
+
+.status-pill.status-active {
+    background: rgba(16, 185, 129, 0.15);
+    color: #047857;
+}
+
+.status-pill.status-completed,
+.status-pill.status-closed {
+    background: rgba(59, 130, 246, 0.15);
+    color: #1d4ed8;
+}
+
+.status-pill.status-archived,
+.status-pill.status-paused {
+    background: rgba(251, 191, 36, 0.18);
+    color: #b45309;
+}
+
+.insight-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.insight-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 20px;
+    padding: 1.5rem 1.75rem;
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.1);
+    display: grid;
+    gap: 1.1rem;
+}
+
+.insight-card header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.insight-card__label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: rgba(15, 23, 42, 0.55);
+}
+
+.insight-card__value {
+    font-size: clamp(2rem, 4vw, 2.65rem);
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.insight-card__hint {
+    margin: 0;
+    font-size: 0.9rem;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.insight-card__trend {
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.16);
+    color: rgba(71, 85, 105, 0.95);
+}
+
+.trend-positive {
+    background: rgba(16, 185, 129, 0.15);
+    color: #047857;
+}
+
+.trend-warning {
+    background: rgba(251, 191, 36, 0.18);
+    color: #b45309;
+}
+
+.dashboard-panels {
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+    gap: 1.75rem;
+}
+
+.recent-surveys__list {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.survey-card {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.9));
+    border-radius: 18px;
+    padding: 1.5rem 1.65rem;
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 1.25rem;
+}
+
+.survey-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.survey-card__header h3 {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.survey-card__category {
+    font-size: 0.85rem;
+    color: rgba(15, 23, 42, 0.55);
+}
+
+.survey-card__meta {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.survey-card__meta span {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(15, 23, 42, 0.5);
+}
+
+.survey-card__meta strong {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.survey-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.panel--actions .panel-body {
+    padding-top: 1rem;
+}
+
+.quick-actions-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1.1rem;
+}
+
+.quick-actions-list__item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1rem;
+    align-items: start;
+    padding: 1rem 1.25rem;
+    border-radius: 16px;
+    background: rgba(248, 250, 252, 0.9);
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.06);
+}
+
+.quick-actions-list__icon {
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.quick-actions-list__content {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.quick-actions-list__content p {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(15, 23, 42, 0.65);
+}
+
+.empty-state {
+    text-align: center;
+    display: grid;
+    gap: 0.75rem;
+    padding: 2rem 1.5rem;
+    border-radius: 18px;
+    background: rgba(248, 250, 252, 0.95);
+}
+
+.empty-state h3 {
+    margin: 0;
+}
+
+@media (max-width: 1080px) {
+    .dashboard-hero__inner {
+        grid-template-columns: 1fr;
+    }
+
+    .dashboard-hero__aside {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .dashboard-panels {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 720px) {
+    .dashboard {
+        margin: 1.5rem auto 3rem;
+        padding: 0 1.25rem;
+    }
+
+    .dashboard-hero {
+        border-radius: 22px;
+        padding: 2rem 1.75rem;
+    }
+
+    .hero-chip {
+        min-width: 0;
+        width: 100%;
+    }
+
+    .survey-card__meta {
+        grid-template-columns: 1fr;
+    }
+
+    .quick-actions-list__item {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 540px) {
+    .dashboard-hero__actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .spotlight-card__actions {
+        flex-direction: column;
+    }
+
+    .survey-card__actions {
+        flex-direction: column;
+    }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1638,231 +1638,238 @@ textarea {
 
 /* Dashboard refresh */
 .dashboard-shell {
-    width: min(1180px, 100% - clamp(2rem, 7vw, 6rem));
-    margin: clamp(2.5rem, 6vw, 5rem) auto clamp(3rem, 7vw, 6rem);
+    width: min(1200px, 100% - clamp(2rem, 7vw, 6rem));
+    margin: clamp(2.8rem, 7vw, 6.2rem) auto clamp(3.2rem, 8vw, 6.4rem);
     display: flex;
     flex-direction: column;
-    gap: clamp(2rem, 5vw, 3.5rem);
+    gap: clamp(2.2rem, 5vw, 3.8rem);
 }
 
 .dashboard-shell > .alert {
     margin: 0;
 }
 
-.dashboard-hero {
+.welcome-hero {
     position: relative;
-    border-radius: 32px;
-    padding: clamp(2.5rem, 5vw, 3.75rem);
-    background: radial-gradient(circle at 15% 20%, rgba(60, 109, 240, 0.2), transparent 45%),
-        radial-gradient(circle at 85% 15%, rgba(34, 211, 238, 0.14), transparent 55%),
-        linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(243, 247, 255, 0.92));
-    box-shadow: 0 38px 80px rgba(15, 23, 42, 0.16);
+    border-radius: 36px;
+    padding: clamp(2.8rem, 6vw, 4rem);
+    background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(76, 106, 255, 0.78));
+    box-shadow: 0 48px 120px rgba(15, 23, 42, 0.45);
     overflow: hidden;
+    color: #e5edff;
 }
 
-.dashboard-hero::before {
-    content: '';
+.welcome-hero__glow {
     position: absolute;
-    inset: 12% auto -45% 58%;
-    width: 420px;
-    height: 420px;
-    background: radial-gradient(circle, rgba(60, 109, 240, 0.35), transparent 65%);
-    filter: blur(8px);
+    inset: auto -30% -55% auto;
+    width: 520px;
+    height: 520px;
+    background: radial-gradient(circle, rgba(96, 165, 250, 0.6), transparent 70%);
+    filter: blur(2px);
+    opacity: 0.65;
+}
+
+.welcome-hero__orb {
+    position: absolute;
+    width: 280px;
+    height: 280px;
+    border-radius: 50%;
+    mix-blend-mode: screen;
     opacity: 0.55;
-    pointer-events: none;
+    filter: blur(10px);
 }
 
-.dashboard-hero::after {
-    content: '';
-    position: absolute;
-    inset: -40% -15% auto auto;
-    width: 420px;
-    height: 420px;
-    background: radial-gradient(circle, rgba(34, 197, 94, 0.18), transparent 70%);
-    filter: blur(6px);
-    opacity: 0.4;
-    pointer-events: none;
+.welcome-hero__orb--one {
+    inset: -60px auto auto 12%;
+    background: radial-gradient(circle, rgba(34, 211, 238, 0.35), transparent 70%);
 }
 
-.dashboard-hero__grid {
+.welcome-hero__orb--two {
+    inset: auto -60px 6% auto;
+    background: radial-gradient(circle, rgba(249, 115, 22, 0.25), transparent 70%);
+}
+
+.welcome-hero__inner {
     position: relative;
-    display: grid;
-    grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
-    gap: clamp(2rem, 4vw, 3.2rem);
-    align-items: stretch;
     z-index: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
+    gap: clamp(2.2rem, 4vw, 3.4rem);
+    align-items: stretch;
 }
 
-.dashboard-hero__content {
+.welcome-hero__copy {
     display: flex;
     flex-direction: column;
-    gap: clamp(1.25rem, 3vw, 1.75rem);
+    gap: clamp(1.4rem, 3vw, 1.9rem);
 }
 
-.dashboard-hero__badge {
+.welcome-hero__badge {
+    align-self: flex-start;
     display: inline-flex;
     align-items: center;
-    gap: 0.45rem;
-    padding: 0.45rem 0.85rem;
+    gap: 0.4rem;
+    padding: 0.5rem 1.05rem;
     border-radius: 999px;
-    background: rgba(60, 109, 240, 0.12);
-    color: var(--color-primary-dark);
-    font-size: 0.75rem;
+    background: rgba(148, 163, 255, 0.18);
+    color: rgba(224, 231, 255, 0.95);
+    font-size: 0.76rem;
     letter-spacing: 0.18em;
     text-transform: uppercase;
     font-weight: 600;
 }
 
-.dashboard-hero__content h1 {
+.welcome-hero__copy h1 {
     margin: 0;
-    font-size: clamp(2.2rem, 5vw, 3.05rem);
-    color: #0b1220;
+    font-size: clamp(2.35rem, 5vw, 3.25rem);
+    color: #fff;
 }
 
-.dashboard-hero__lead {
+.welcome-hero__lead {
     margin: 0;
-    font-size: 1.05rem;
-    line-height: 1.7;
-    color: rgba(11, 18, 32, 0.74);
-    max-width: 560px;
+    font-size: clamp(1rem, 2.3vw, 1.12rem);
+    color: rgba(226, 232, 255, 0.86);
+    line-height: 1.75;
+    max-width: 62ch;
 }
 
-.dashboard-hero__lead strong {
-    color: #0b1220;
+.welcome-hero__lead strong {
+    color: #fff;
 }
 
-.dashboard-hero__highlights {
+.welcome-hero__stats {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: clamp(1.1rem, 3vw, 1.5rem);
 }
 
-.highlight-card {
+.stat-bubble {
     position: relative;
+    border-radius: 22px;
+    padding: 1.4rem 1.5rem 1.6rem;
+    background: rgba(15, 23, 42, 0.38);
+    border: 1px solid rgba(148, 163, 255, 0.2);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 22px 45px rgba(15, 23, 42, 0.4);
     display: grid;
-    gap: 0.4rem;
-    padding: 1.15rem 1.35rem 1.4rem;
-    border-radius: 18px;
-    background: rgba(255, 255, 255, 0.82);
-    box-shadow: 0 22px 48px rgba(60, 109, 240, 0.18);
-    backdrop-filter: blur(18px);
-    overflow: hidden;
+    gap: 0.55rem;
 }
 
-.highlight-card::after {
-    content: '';
-    position: absolute;
-    inset: auto 0 0 auto;
-    width: 110px;
-    height: 110px;
-    background: radial-gradient(circle at bottom right, rgba(60, 109, 240, 0.18), transparent 70%);
-    opacity: 0.5;
-    transform: translate(30%, 30%);
+.stat-bubble--accent {
+    background: linear-gradient(150deg, rgba(37, 99, 235, 0.85), rgba(79, 70, 229, 0.75));
+    border-color: rgba(191, 219, 254, 0.35);
 }
 
-.highlight-card__label {
+.stat-bubble__label {
     font-size: 0.75rem;
-    letter-spacing: 0.14em;
+    letter-spacing: 0.16em;
     text-transform: uppercase;
-    color: rgba(11, 18, 32, 0.55);
+    color: rgba(226, 232, 255, 0.7);
     font-weight: 600;
 }
 
-.highlight-card__value {
-    font-size: 1.65rem;
+.stat-bubble__value {
+    font-size: 2.05rem;
     font-weight: 700;
-    color: #0b1220;
-    position: relative;
-    z-index: 1;
+    color: #fff;
 }
 
-.highlight-card__meta {
-    font-size: 0.88rem;
-    color: rgba(11, 18, 32, 0.62);
-    position: relative;
-    z-index: 1;
+.stat-bubble__meta {
+    font-size: 0.92rem;
+    color: rgba(226, 232, 255, 0.78);
 }
 
-.highlight-card__progress {
+.stat-bubble__progress {
     position: relative;
-    display: block;
     height: 6px;
     border-radius: 999px;
-    background: rgba(60, 109, 240, 0.16);
+    background: rgba(226, 232, 255, 0.2);
     overflow: hidden;
-    margin-top: 0.35rem;
 }
 
-.highlight-card__progress span {
-    display: block;
-    height: 100%;
+.stat-bubble__progress span {
+    position: absolute;
+    inset: 0;
     border-radius: inherit;
-    background: linear-gradient(90deg, var(--color-primary), #5a8df4);
+    background: linear-gradient(90deg, rgba(59, 130, 246, 0.9), rgba(129, 140, 248, 0.95));
 }
 
-.dashboard-hero__actions {
+.welcome-hero__actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.9rem;
 }
 
-.dashboard-hero__actions .button-link {
-    font-weight: 600;
-    color: rgba(11, 18, 32, 0.7);
+.welcome-hero__actions .button-primary {
+    box-shadow: 0 16px 35px rgba(59, 130, 246, 0.45);
 }
 
-.dashboard-hero__panel {
+.welcome-hero__actions .button-secondary {
+    color: #0b1220;
+    background: #fff;
+    border: none;
+}
+
+.welcome-hero__actions .button-link {
+    color: rgba(224, 231, 255, 0.9);
+}
+
+.welcome-hero__panels {
     display: grid;
     gap: 1.4rem;
 }
 
-.glass-card {
-    background: rgba(255, 255, 255, 0.78);
+.welcome-panel {
+    background: rgba(255, 255, 255, 0.92);
     border-radius: 26px;
-    padding: clamp(1.5rem, 3vw, 1.9rem);
-    box-shadow: 0 26px 60px rgba(15, 23, 42, 0.16);
-    backdrop-filter: blur(20px);
-    border: 1px solid rgba(255, 255, 255, 0.65);
+    padding: clamp(1.6rem, 3vw, 2.1rem);
+    box-shadow: 0 32px 70px rgba(15, 23, 42, 0.22);
     display: grid;
     gap: 1.1rem;
+    color: #0b1220;
 }
 
-.glass-card__badge {
+.welcome-panel__badge {
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    padding: 0.45rem 0.85rem;
+    padding: 0.45rem 0.9rem;
     border-radius: 999px;
-    background: rgba(60, 109, 240, 0.12);
-    color: var(--color-primary-dark);
+    background: rgba(59, 130, 246, 0.12);
+    color: #3b82f6;
     font-size: 0.75rem;
     letter-spacing: 0.16em;
     text-transform: uppercase;
     font-weight: 600;
 }
 
-.glass-card h3 {
+.welcome-panel h2 {
     margin: 0;
-    font-size: 1.25rem;
-    color: #0b1220;
+    font-size: 1.4rem;
+    color: #111827;
+}
+
+.welcome-panel p {
+    margin: 0;
+    color: rgba(17, 24, 39, 0.72);
+    line-height: 1.6;
 }
 
 .ai-config__list {
     display: grid;
-    gap: 0.7rem;
+    gap: 0.8rem;
     margin: 0;
 }
 
 .ai-config__list div {
     display: flex;
     justify-content: space-between;
-    gap: 0.85rem;
-    font-size: 0.95rem;
+    gap: 0.9rem;
+    font-size: 0.96rem;
 }
 
 .ai-config__list dt {
     font-weight: 500;
-    color: rgba(11, 18, 32, 0.55);
+    color: rgba(17, 24, 39, 0.6);
 }
 
 .ai-config__list dd {
@@ -1876,284 +1883,191 @@ textarea {
     max-width: 220px;
 }
 
-.ai-config__hint {
-    margin: 0;
-    font-size: 0.85rem;
-    color: rgba(11, 18, 32, 0.58);
+.welcome-panel__cta {
+    justify-self: flex-start;
 }
 
-.ai-config__action {
-    justify-self: start;
+.welcome-panel__hint {
+    font-size: 0.88rem;
+    color: rgba(17, 24, 39, 0.55);
 }
 
-.spotlight-card {
-    background: rgba(248, 250, 252, 0.88);
-    border-radius: 22px;
-    padding: 1.6rem 1.75rem;
-    display: grid;
-    gap: 1.1rem;
-    border: 1px solid rgba(148, 163, 184, 0.16);
-    box-shadow: 0 20px 46px rgba(15, 23, 42, 0.1);
-}
-
-.spotlight-card__label {
-    font-size: 0.75rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: rgba(11, 18, 32, 0.55);
-    font-weight: 600;
-}
-
-.spotlight-card h3 {
-    margin: 0;
-    font-size: 1.3rem;
-}
-
-.spotlight-card__meta {
+.spotlight-meta {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.55rem;
-    font-size: 0.95rem;
+    gap: 0.75rem;
+    font-size: 0.96rem;
+    color: rgba(17, 24, 39, 0.75);
 }
 
-.spotlight-card__meta strong {
-    font-weight: 600;
-}
-
-.spotlight-card p {
-    margin: 0;
-    color: rgba(11, 18, 32, 0.62);
-}
-
-.spotlight-card__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.85rem;
-}
-
-.status-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.35rem 0.65rem;
-    border-radius: 999px;
-    font-size: 0.8rem;
-    font-weight: 600;
-    text-transform: capitalize;
-    background: rgba(99, 102, 241, 0.12);
-    color: var(--color-primary);
-}
-
-.status-pill.status-draft {
-    background: rgba(148, 163, 184, 0.16);
-    color: rgba(71, 85, 105, 0.95);
-}
-
-.status-pill.status-active {
-    background: rgba(16, 185, 129, 0.15);
-    color: #047857;
-}
-
-.status-pill.status-completed,
-.status-pill.status-closed {
-    background: rgba(59, 130, 246, 0.15);
-    color: #1d4ed8;
-}
-
-.status-pill.status-archived,
-.status-pill.status-paused {
-    background: rgba(251, 191, 36, 0.18);
-    color: #b45309;
-}
-
-.dashboard-overview {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-}
-
-.overview-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-    gap: 1.35rem;
-}
-
-.overview-card {
-    position: relative;
-    display: grid;
-    gap: 0.65rem;
-    padding: 1.6rem 1.7rem;
-    border-radius: 22px;
-    background: rgba(255, 255, 255, 0.94);
-    box-shadow: 0 24px 52px rgba(15, 23, 42, 0.12);
-    overflow: hidden;
-}
-
-.overview-card::before {
-    content: '';
-    position: absolute;
-    inset: auto auto -40% -10%;
-    width: 220px;
-    height: 220px;
-    background: radial-gradient(circle, rgba(60, 109, 240, 0.14), transparent 70%);
-    opacity: 0.55;
-}
-
-.overview-card__icon {
-    width: 44px;
-    height: 44px;
-    border-radius: 14px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.35rem;
-    background: rgba(60, 109, 240, 0.16);
-    color: var(--color-primary);
-}
-
-.overview-card--success .overview-card__icon {
-    background: rgba(16, 185, 129, 0.18);
-    color: #0f766e;
-}
-
-.overview-card--warning .overview-card__icon {
-    background: rgba(251, 191, 36, 0.18);
-    color: #b45309;
-}
-
-.overview-card__label {
-    font-size: 0.78rem;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: rgba(11, 18, 32, 0.58);
-    font-weight: 600;
-}
-
-.overview-card__value {
-    font-size: 2.05rem;
-    font-weight: 700;
-    color: #0b1220;
-    margin: 0;
-}
-
-.overview-card__hint {
-    margin: 0;
-    font-size: 0.92rem;
-    color: rgba(11, 18, 32, 0.62);
-}
-
-.dashboard-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
-    gap: clamp(1.75rem, 4vw, 2.75rem);
-}
-
-.dashboard-layout__aside {
-    display: grid;
-    gap: 1.5rem;
-}
-
-.surface-card {
-    background: rgba(255, 255, 255, 0.92);
-    border-radius: 26px;
-    padding: clamp(1.6rem, 3vw, 2.15rem);
-    box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
-    display: grid;
-    gap: 1.5rem;
-}
-
-.surface-card__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-}
-
-.surface-card__header h2 {
-    margin: 0;
-    font-size: 1.4rem;
-}
-
-.surface-card__description {
-    margin: 0;
-    color: rgba(11, 18, 32, 0.6);
-    font-size: 0.95rem;
-}
-
-.survey-list {
-    display: grid;
-    gap: 1.1rem;
-}
-
-.survey-item {
-    border: 1px solid rgba(60, 109, 240, 0.1);
-    border-radius: 20px;
-    padding: 1.25rem 1.4rem;
-    background: rgba(248, 250, 252, 0.9);
-    display: grid;
-    gap: 1rem;
-}
-
-.survey-item__header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
-}
-
-.survey-item__title {
-    margin: 0;
-    font-size: 1.15rem;
-}
-
-.survey-item__category {
-    font-size: 0.85rem;
-    color: rgba(11, 18, 32, 0.58);
-    margin-top: 0.35rem;
-}
-
-.survey-item__meta {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 1rem;
-    font-size: 0.95rem;
-    color: rgba(11, 18, 32, 0.62);
-}
-
-.survey-item__meta span {
+.spotlight-meta span {
     display: block;
     font-size: 0.78rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
-    color: rgba(11, 18, 32, 0.45);
-    margin-bottom: 0.2rem;
+    color: rgba(17, 24, 39, 0.5);
+    margin-bottom: 0.25rem;
 }
 
-.survey-item__actions {
+.spotlight-meta strong {
+    font-weight: 600;
+    color: #111827;
+}
+
+.welcome-panel__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.85rem;
+    gap: 0.8rem;
 }
 
-.empty-state {
+.welcome-panel__actions .button-link {
+    color: var(--color-primary);
+}
+
+.dashboard-panels {
+    display: flex;
+    flex-direction: column;
+    gap: 1.8rem;
+}
+
+.panels-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
+    gap: clamp(1.8rem, 4vw, 2.8rem);
+}
+
+.panel {
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 28px;
+    padding: clamp(1.8rem, 3vw, 2.3rem);
+    box-shadow: 0 32px 70px rgba(15, 23, 42, 0.16);
+    display: grid;
+    gap: 1.6rem;
+}
+
+.panel__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.panel__header h2 {
+    margin: 0;
+    font-size: 1.5rem;
+    color: #0f172a;
+}
+
+.panel__description {
+    margin: 0.4rem 0 0;
+    font-size: 0.95rem;
+    color: rgba(15, 23, 42, 0.64);
+}
+
+.panel__header .button-link {
+    align-self: center;
+}
+
+.empty-block {
     text-align: center;
     display: grid;
-    gap: 0.85rem;
-    padding: 2.4rem 1.75rem;
-    border-radius: 20px;
-    background: rgba(248, 250, 252, 0.95);
+    gap: 0.9rem;
+    padding: 2.5rem 1.9rem;
+    border-radius: 22px;
+    background: rgba(248, 250, 252, 0.9);
+    border: 1px dashed rgba(148, 163, 255, 0.3);
 }
 
-.empty-state h3 {
+.empty-block h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.empty-block p {
+    margin: 0;
+    color: rgba(15, 23, 42, 0.62);
+}
+
+.survey-cards {
+    display: grid;
+    gap: 1.1rem;
+}
+
+.survey-card {
+    border-radius: 22px;
+    border: 1px solid rgba(148, 163, 255, 0.22);
+    background: linear-gradient(160deg, rgba(248, 250, 252, 0.92), rgba(255, 255, 255, 0.95));
+    box-shadow: 0 22px 48px rgba(15, 23, 42, 0.12);
+    padding: 1.35rem 1.5rem;
+    display: grid;
+    gap: 1.1rem;
+}
+
+.survey-card__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.1rem;
+}
+
+.survey-card__title {
+    margin: 0;
+    font-size: 1.2rem;
+    color: #0f172a;
+}
+
+.survey-card__category {
+    display: inline-block;
+    margin-top: 0.35rem;
+    font-size: 0.83rem;
+    color: rgba(15, 23, 42, 0.55);
+}
+
+.survey-card__meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
     margin: 0;
 }
 
-.quick-actions-list {
+.survey-card__meta div {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.survey-card__meta dt {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(15, 23, 42, 0.5);
+}
+
+.survey-card__meta dd {
+    margin: 0;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.survey-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.9rem;
+}
+
+.quick-actions {
+    display: grid;
+    gap: 1.2rem;
+}
+
+.quick-actions h2 {
+    margin: 0;
+    font-size: 1.3rem;
+    color: #0f172a;
+}
+
+.quick-actions ul {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -2161,117 +2075,107 @@ textarea {
     gap: 1rem;
 }
 
-.quick-actions-list__item {
+.quick-actions li {
     display: grid;
     grid-template-columns: auto 1fr;
-    gap: 1rem;
+    gap: 0.9rem;
     align-items: start;
-    padding: 1.05rem 1.25rem;
-    border-radius: 18px;
-    background: rgba(248, 250, 252, 0.9);
-    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.07);
+    padding: 1.1rem 1.25rem;
+    border-radius: 20px;
+    background: rgba(248, 250, 252, 0.94);
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    box-shadow: 0 20px 42px rgba(15, 23, 42, 0.08);
 }
 
-.quick-actions-list__icon {
-    font-size: 1.5rem;
+.quick-actions__icon {
+    font-size: 1.55rem;
     line-height: 1;
 }
 
-.quick-actions-list__content {
-    display: grid;
-    gap: 0.45rem;
-}
-
-.quick-actions-list__content strong {
+.quick-actions li strong {
     font-size: 1rem;
+    color: #111827;
 }
 
-.quick-actions-list__content p {
-    margin: 0;
-    font-size: 0.95rem;
-    color: rgba(11, 18, 32, 0.63);
+.quick-actions li p {
+    margin: 0.35rem 0 0;
+    font-size: 0.94rem;
+    color: rgba(17, 24, 39, 0.6);
 }
 
-.support-card {
-    background: rgba(248, 250, 252, 0.92);
+.support-callout {
     border-radius: 20px;
-    padding: 1.4rem 1.55rem;
+    padding: 1.5rem 1.6rem;
+    background: linear-gradient(140deg, rgba(224, 231, 255, 0.45), rgba(191, 219, 254, 0.65));
+    border: 1px solid rgba(148, 163, 255, 0.35);
     display: grid;
     gap: 0.6rem;
-    border: 1px dashed rgba(99, 102, 241, 0.3);
+    color: #0f172a;
 }
 
-.support-card strong {
+.support-callout strong {
     font-size: 1.05rem;
 }
 
-.support-card p {
+.support-callout p {
     margin: 0;
-    color: rgba(11, 18, 32, 0.63);
-    line-height: 1.55;
-}
-
-.support-card p + p {
-    margin-top: 0.4rem;
+    color: rgba(15, 23, 42, 0.65);
+    line-height: 1.6;
 }
 
 @media (max-width: 1180px) {
     .dashboard-shell {
-        width: calc(100% - clamp(1.5rem, 5vw, 3rem));
+        width: calc(100% - clamp(1.5rem, 5vw, 3.2rem));
     }
 }
 
-@media (max-width: 1024px) {
-    .dashboard-hero__grid {
+@media (max-width: 1040px) {
+    .welcome-hero__inner {
         grid-template-columns: 1fr;
     }
 
-    .dashboard-hero__panel {
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    .welcome-hero__panels {
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     }
 
-    .dashboard-layout {
+    .panels-grid {
         grid-template-columns: 1fr;
     }
 }
 
 @media (max-width: 720px) {
     .dashboard-shell {
-        width: calc(100% - 2.5rem);
-        margin: 1.75rem auto 3.5rem;
+        width: calc(100% - 2.4rem);
+        margin: 1.8rem auto 3.5rem;
     }
 
-    .dashboard-hero {
-        border-radius: 26px;
-        padding: 2.2rem 1.85rem;
+    .welcome-hero {
+        border-radius: 28px;
+        padding: 2.4rem 2rem;
     }
 
-    .dashboard-hero__highlights {
-        grid-template-columns: 1fr;
-    }
-
-    .overview-grid {
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    }
-
-    .surface-card {
-        border-radius: 22px;
-    }
-
-    .quick-actions-list__item {
-        grid-template-columns: 1fr;
-    }
-}
-
-@media (max-width: 540px) {
-    .dashboard-hero__actions {
+    .welcome-hero__actions {
         flex-direction: column;
         align-items: stretch;
     }
 
-    .spotlight-card__actions,
-    .survey-item__actions {
+    .survey-card__actions {
         flex-direction: column;
+        align-items: stretch;
+    }
+
+    .welcome-panel,
+    .panel {
+        border-radius: 24px;
     }
 }
 
+@media (max-width: 520px) {
+    .quick-actions li {
+        grid-template-columns: 1fr;
+    }
+
+    .welcome-hero__stats {
+        grid-template-columns: 1fr;
+    }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -40,6 +40,78 @@ a:hover {
     padding: 0 1.5rem;
 }
 
+.page {
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 60px);
+}
+
+.page-hero {
+    position: relative;
+    background: radial-gradient(circle at 12% 20%, rgba(60, 109, 240, 0.18), transparent 55%),
+        linear-gradient(135deg, rgba(60, 109, 240, 0.12), rgba(255, 255, 255, 0.1));
+    padding: 4rem 0 3.5rem;
+    margin-bottom: -2.5rem;
+    overflow: hidden;
+}
+
+.page-hero::after {
+    content: '';
+    position: absolute;
+    inset: auto -15% -45% auto;
+    width: 340px;
+    height: 340px;
+    background: radial-gradient(circle, rgba(60, 109, 240, 0.22), transparent 70%);
+    filter: blur(2px);
+    opacity: 0.8;
+}
+
+.page-hero__content {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 2rem;
+    position: relative;
+    z-index: 1;
+}
+
+.page-hero__text {
+    max-width: 540px;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.page-hero__eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: rgba(31, 41, 51, 0.7);
+    font-weight: 600;
+}
+
+.page-hero__title {
+    margin: 0;
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    color: var(--color-text);
+}
+
+.page-hero__subtitle {
+    margin: 0;
+    font-size: 1rem;
+    color: rgba(31, 41, 51, 0.75);
+}
+
+.page-hero__actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.page--surveys > .container {
+    margin-top: 3.5rem;
+    margin-bottom: 3rem;
+}
+
 .top-nav {
     display: flex;
     align-items: center;
@@ -605,103 +677,104 @@ textarea {
     margin: 0;
 }
 
-.survey-insights {
+.insight-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 1.25rem;
-    margin-bottom: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    gap: 1.2rem;
+    margin: 0 0 2.5rem;
 }
 
 .insight-card {
     position: relative;
-    background: linear-gradient(135deg, rgba(60, 109, 240, 0.12), rgba(255, 255, 255, 0.95));
-    border-radius: var(--radius);
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
-    display: grid;
-    gap: 0.35rem;
-    overflow: hidden;
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 18px;
+    padding: 1.75rem;
+    border: 1px solid rgba(60, 109, 240, 0.08);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 1rem;
 }
 
-.insight-card::after {
-    content: '';
-    position: absolute;
-    inset: auto -40% -40% auto;
-    width: 120px;
-    height: 120px;
-    background: radial-gradient(circle at center, rgba(60, 109, 240, 0.18), transparent 60%);
-    transform: rotate(25deg);
+.insight-card__meta {
+    display: grid;
+    gap: 0.35rem;
 }
 
 .insight-card__label {
-    font-size: 0.75rem;
+    font-size: 0.78rem;
     text-transform: uppercase;
-    letter-spacing: 0.16em;
-    color: var(--color-muted);
-    font-weight: 600;
+    letter-spacing: 0.18em;
+    color: rgba(31, 41, 51, 0.6);
+    font-weight: 700;
 }
 
 .insight-card__value {
-    font-size: 2rem;
+    font-size: clamp(1.8rem, 4vw, 2.4rem);
     font-weight: 700;
     color: var(--color-text);
 }
 
 .insight-card__hint {
-    font-size: 0.9rem;
-    color: var(--color-muted);
+    font-size: 0.85rem;
+    color: rgba(31, 41, 51, 0.6);
 }
 
 .survey-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.75rem;
 }
 
 .survey-card {
     background: rgba(255, 255, 255, 0.95);
-    border-radius: var(--radius);
+    border-radius: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
     padding: 1.75rem;
-    box-shadow: var(--shadow);
+    box-shadow: 0 14px 38px rgba(15, 23, 42, 0.12);
     display: grid;
     gap: 1.5rem;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
     position: relative;
     overflow: hidden;
-    border: 1px solid rgba(60, 109, 240, 0.08);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.survey-card::before {
+.survey-card::after {
     content: '';
     position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(60, 109, 240, 0.08), transparent 55%);
+    inset: -45% 45% auto auto;
+    width: 220px;
+    height: 220px;
+    background: radial-gradient(circle, rgba(60, 109, 240, 0.18), transparent 65%);
     opacity: 0;
-    transition: opacity 0.2s ease;
+    transition: opacity 0.25s ease;
 }
 
 .survey-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 18px 35px rgba(60, 109, 240, 0.18);
+    transform: translateY(-6px);
+    border-color: rgba(60, 109, 240, 0.35);
+    box-shadow: 0 24px 44px rgba(15, 23, 42, 0.18);
 }
 
-.survey-card:hover::before {
+.survey-card:hover::after {
     opacity: 1;
 }
 
-.survey-card > * {
-    position: relative;
-    z-index: 1;
+.survey-card__body {
+    display: grid;
+    gap: 1rem;
 }
 
 .survey-card__header {
     display: grid;
-    gap: 0.5rem;
+    gap: 0.75rem;
 }
 
-.survey-card__header h2 {
-    margin: 0.5rem 0 0.75rem;
-    font-size: 1.2rem;
+.survey-card__title {
+    margin: 0;
+    font-size: clamp(1.2rem, 3vw, 1.5rem);
+    color: var(--color-text);
 }
 
 .survey-card__status {
@@ -719,16 +792,19 @@ textarea {
 }
 
 .survey-card__description {
-    color: var(--color-muted);
+    color: rgba(31, 41, 51, 0.7);
     margin: 0;
-    font-size: 0.95rem;
-    line-height: 1.5;
+    font-size: 0.98rem;
+    line-height: 1.55;
 }
 
 .survey-meta {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem 1.25rem;
+    padding: 1.25rem;
+    border-radius: 14px;
+    background: rgba(60, 109, 240, 0.05);
 }
 
 .survey-meta dt {
@@ -749,15 +825,15 @@ textarea {
     justify-content: space-between;
     align-items: flex-start;
     flex-wrap: wrap;
-    gap: 0.75rem;
-    border-top: 1px solid rgba(60, 109, 240, 0.12);
-    padding-top: 1rem;
+    gap: 0.9rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+    padding-top: 1.1rem;
 }
 
 .survey-card__chips {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.55rem;
 }
 
 .chip {
@@ -957,12 +1033,18 @@ textarea {
         align-items: flex-start;
     }
 
-    .page-header {
+    .page-hero {
+        margin-bottom: -1.5rem;
+        padding: 3rem 0 2.5rem;
+    }
+
+    .page-hero__content {
         flex-direction: column;
         align-items: flex-start;
     }
 
     .page-header__actions,
+    .page-hero__actions,
     .hero-actions,
     .inline-form,
     .inline-actions,
@@ -975,7 +1057,7 @@ textarea {
         padding: 1.5rem;
     }
 
-    .survey-insights {
+    .insight-grid {
         grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
         gap: 1rem;
     }
@@ -984,12 +1066,21 @@ textarea {
         font-size: 1.6rem;
     }
 
+    .survey-meta {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+
     .survey-card__footer {
         flex-direction: column;
         align-items: stretch;
     }
 
     .survey-card__chips {
+        justify-content: flex-start;
+    }
+
+    .survey-card__actions {
+        width: 100%;
         justify-content: flex-start;
     }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -605,6 +605,53 @@ textarea {
     margin: 0;
 }
 
+.survey-insights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.25rem;
+    margin-bottom: 2rem;
+}
+
+.insight-card {
+    position: relative;
+    background: linear-gradient(135deg, rgba(60, 109, 240, 0.12), rgba(255, 255, 255, 0.95));
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 0.35rem;
+    overflow: hidden;
+}
+
+.insight-card::after {
+    content: '';
+    position: absolute;
+    inset: auto -40% -40% auto;
+    width: 120px;
+    height: 120px;
+    background: radial-gradient(circle at center, rgba(60, 109, 240, 0.18), transparent 60%);
+    transform: rotate(25deg);
+}
+
+.insight-card__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--color-muted);
+    font-weight: 600;
+}
+
+.insight-card__value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.insight-card__hint {
+    font-size: 0.9rem;
+    color: var(--color-muted);
+}
+
 .survey-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -612,12 +659,44 @@ textarea {
 }
 
 .survey-card {
-    background: rgba(255, 255, 255, 0.92);
+    background: rgba(255, 255, 255, 0.95);
     border-radius: var(--radius);
     padding: 1.75rem;
     box-shadow: var(--shadow);
     display: grid;
     gap: 1.5rem;
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(60, 109, 240, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.survey-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(60, 109, 240, 0.08), transparent 55%);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.survey-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 35px rgba(60, 109, 240, 0.18);
+}
+
+.survey-card:hover::before {
+    opacity: 1;
+}
+
+.survey-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+.survey-card__header {
+    display: grid;
+    gap: 0.5rem;
 }
 
 .survey-card__header h2 {
@@ -625,10 +704,25 @@ textarea {
     font-size: 1.2rem;
 }
 
-.survey-card__header p {
+.survey-card__status {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+    color: var(--color-muted);
+}
+
+.survey-card__status-date {
+    font-size: 0.8rem;
+    color: var(--color-muted);
+}
+
+.survey-card__description {
     color: var(--color-muted);
     margin: 0;
     font-size: 0.95rem;
+    line-height: 1.5;
 }
 
 .survey-meta {
@@ -648,6 +742,54 @@ textarea {
 .survey-meta dd {
     margin: 0;
     font-weight: 600;
+}
+
+.survey-card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    border-top: 1px solid rgba(60, 109, 240, 0.12);
+    padding-top: 1rem;
+}
+
+.survey-card__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    background: rgba(60, 109, 240, 0.12);
+    color: var(--color-primary);
+    border-radius: 999px;
+    padding: 0.25rem 0.65rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.chip-muted {
+    background: rgba(107, 114, 128, 0.15);
+    color: #4b5563;
+}
+
+.chip-success {
+    background: rgba(34, 197, 94, 0.15);
+    color: #15803d;
+}
+
+.chip-warning {
+    background: rgba(245, 158, 11, 0.18);
+    color: #b45309;
+}
+
+.chip-danger {
+    background: rgba(217, 48, 37, 0.16);
+    color: var(--color-danger);
 }
 
 .survey-card__actions {
@@ -831,5 +973,23 @@ textarea {
 
     .survey-card {
         padding: 1.5rem;
+    }
+
+    .survey-insights {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
+    }
+
+    .insight-card__value {
+        font-size: 1.6rem;
+    }
+
+    .survey-card__footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .survey-card__chips {
+        justify-content: flex-start;
     }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -26,11 +26,12 @@ body {
 }
 
 .auth-body {
-    background: linear-gradient(145deg, #e7f0ff 0%, #f9f5ff 45%, #ffffff 100%);
+    background: linear-gradient(135deg, #e3f0ff 0%, #f5f4ff 55%, #ffffff 100%);
+    min-height: 100vh;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: clamp(2rem, 6vw, 4rem) 1.25rem;
+    padding: clamp(2rem, 6vw, 4rem) clamp(1.25rem, 5vw, 2.5rem);
 }
 
 a {
@@ -215,157 +216,150 @@ a:hover {
 
 
 .auth-wrapper {
-    width: min(1180px, 100%);
-    margin: clamp(1.5rem, 5vw, 3rem) auto;
-    padding: 0 clamp(1rem, 4vw, 2rem);
+    width: min(1120px, 100%);
+    margin: 0 auto;
 }
 
 .auth-panel {
     position: relative;
     display: grid;
-    grid-template-columns: minmax(340px, 1.05fr) minmax(320px, 0.8fr);
-    background: rgba(255, 255, 255, 0.88);
-    border-radius: 32px;
-    box-shadow: 0 32px 60px rgba(15, 23, 42, 0.14);
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    background: rgba(255, 255, 255, 0.68);
+    border-radius: 28px;
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    box-shadow: 0 28px 60px rgba(24, 40, 72, 0.12);
     overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.65);
-    backdrop-filter: blur(18px);
-    isolation: isolate;
+    backdrop-filter: blur(20px);
 }
 
-.auth-panel::before,
-.auth-panel::after {
+.auth-visual {
+    position: relative;
+    padding: clamp(2.5rem, 6vw, 3.75rem);
+    display: grid;
+    align-content: space-between;
+    gap: clamp(2rem, 4vw, 2.75rem);
+    background: linear-gradient(145deg, #1b3a74 0%, #2f7bbf 45%, #2fc0c2 100%);
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.auth-visual__content {
+    display: grid;
+    gap: clamp(1.75rem, 4vw, 2.6rem);
+}
+
+.auth-visual::before,
+.auth-visual::after {
     content: '';
     position: absolute;
-    border-radius: 50%;
-    filter: blur(0);
-    z-index: -1;
+    border-radius: 999px;
+    mix-blend-mode: screen;
+    opacity: 0.4;
 }
 
-.auth-panel::before {
-    width: 420px;
-    height: 420px;
-    inset: -28% auto auto -22%;
-    background: radial-gradient(circle, rgba(91, 138, 255, 0.22), transparent 70%);
+.auth-visual::before {
+    width: 220px;
+    height: 220px;
+    inset: -60px -80px auto auto;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.55), transparent 65%);
 }
 
-.auth-panel::after {
-    width: 360px;
-    height: 360px;
-    inset: auto -25% -35% auto;
-    background: radial-gradient(circle, rgba(79, 70, 229, 0.18), transparent 70%);
+.auth-visual::after {
+    width: 280px;
+    height: 280px;
+    inset: auto auto -120px -120px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.35), transparent 70%);
 }
 
-.auth-showcase {
+.auth-visual > * {
     position: relative;
-    padding: clamp(2.75rem, 6vw, 3.75rem);
-    display: flex;
-    flex-direction: column;
-    gap: clamp(1.75rem, 4vw, 2.75rem);
-    background: linear-gradient(160deg, rgba(59, 130, 246, 0.18) 0%, rgba(79, 70, 229, 0.14) 35%, rgba(14, 165, 233, 0.12) 100%);
+    z-index: 1;
 }
 
-.auth-showcase__header {
-    display: grid;
-    gap: 1rem;
-    max-width: 520px;
-}
-
-.auth-eyebrow {
+.auth-badge {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.5rem;
+    padding: 0.45rem 0.95rem;
+    border-radius: 999px;
     font-size: 0.75rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    letter-spacing: 0.22em;
+    background: rgba(255, 255, 255, 0.18);
+    color: rgba(255, 255, 255, 0.85);
     font-weight: 600;
-    color: rgba(17, 24, 39, 0.7);
 }
 
-.auth-showcase h1 {
+.auth-heading {
+    display: grid;
+    gap: 1rem;
+}
+
+.auth-heading h1 {
     margin: 0;
-    font-size: clamp(2.2rem, 4.8vw, 2.9rem);
-    line-height: 1.15;
-    color: #0f172a;
+    font-size: clamp(2rem, 4.4vw, 2.8rem);
+    line-height: 1.2;
+    color: #fff;
 }
 
-.auth-showcase p {
+.auth-heading p {
     margin: 0;
     font-size: 1rem;
-    color: rgba(15, 23, 42, 0.7);
+    line-height: 1.6;
+    color: rgba(240, 247, 255, 0.85);
 }
 
-.auth-showcase__cards {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(140px, 1fr));
-    gap: 1.25rem;
-}
-
-.auth-insight {
-    display: grid;
-    gap: 0.45rem;
-    padding: 1.4rem 1.6rem;
-    border-radius: 22px;
-    background: linear-gradient(140deg, rgba(255, 255, 255, 0.82), rgba(231, 240, 255, 0.9));
-    border: 1px solid rgba(203, 213, 225, 0.4);
-    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
-    backdrop-filter: blur(10px);
-}
-
-.auth-insight__value {
-    font-size: 2rem;
-    font-weight: 700;
-    color: #1d4ed8;
-}
-
-.auth-insight__title {
-    margin: 0;
-    font-size: 1.05rem;
-    color: #0f172a;
-}
-
-.auth-insight__text {
-    margin: 0;
-    font-size: 0.9rem;
-    color: rgba(15, 23, 42, 0.65);
-}
-
-.auth-feature-chips {
-    list-style: none;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.65rem;
+.auth-benefits {
     margin: 0;
     padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.85rem;
 }
 
-.auth-feature-chips li {
-    padding: 0.55rem 1.1rem;
-    border-radius: 999px;
-    background: rgba(15, 23, 42, 0.08);
-    color: rgba(15, 23, 42, 0.75);
-    font-size: 0.85rem;
-    font-weight: 600;
-}
-
-.auth-sidebar {
-    position: relative;
+.auth-benefits li {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: clamp(3rem, 7vw, 4rem);
-    background: linear-gradient(180deg, rgba(15, 23, 42, 0.02) 0%, rgba(59, 130, 246, 0.05) 100%);
+    align-items: flex-start;
+    gap: 0.75rem;
+    font-size: 0.95rem;
+    color: rgba(240, 247, 255, 0.9);
+}
+
+.auth-benefits li::before {
+    content: '\2713';
+    font-size: 0.85rem;
+    line-height: 1.5;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.2);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+}
+
+.auth-support {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: rgba(240, 247, 255, 0.75);
+}
+
+.auth-support span {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.88);
+}
+
+.auth-support a {
+    color: #ffffff;
+    font-weight: 600;
 }
 
 .auth-card {
-    width: min(420px, 100%);
-    background: #ffffff;
-    border-radius: 26px;
-    border: 1px solid rgba(229, 231, 235, 0.8);
-    box-shadow: 0 28px 45px rgba(30, 64, 175, 0.18);
-    padding: clamp(2.5rem, 5vw, 3.25rem);
-    display: flex;
-    flex-direction: column;
+    padding: clamp(2.5rem, 5vw, 3.5rem);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.98) 60%, #ffffff 100%);
+    display: grid;
     gap: 1.75rem;
 }
 
@@ -376,148 +370,121 @@ a:hover {
 
 .auth-card-header h2 {
     margin: 0;
-    font-size: clamp(1.6rem, 3.2vw, 1.85rem);
-    color: #111827;
+    font-size: 1.8rem;
+    color: var(--color-text);
 }
 
 .auth-card-header p {
     margin: 0;
     font-size: 0.95rem;
-    color: rgba(55, 65, 81, 0.85);
+    color: var(--color-muted);
 }
 
 .auth-form {
     display: grid;
-    gap: 1.35rem;
+    gap: 1.25rem;
 }
 
 .form-field {
     display: grid;
-    gap: 0.6rem;
+    gap: 0.5rem;
+}
+
+.form-field label {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--color-text);
 }
 
 .field-label {
     display: flex;
-    align-items: center;
     justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    font-size: 0.9rem;
 }
 
 .field-action {
+    font-weight: 500;
     font-size: 0.85rem;
-    color: var(--color-primary);
-    font-weight: 600;
-    opacity: 0.85;
-}
-
-.field-action[aria-disabled="true"] {
-    pointer-events: none;
-    cursor: not-allowed;
-    opacity: 0.45;
 }
 
 .auth-card input[type="email"],
 .auth-card input[type="password"] {
-    padding: 0.85rem 1rem;
-    border-radius: 14px;
-    border: 1px solid rgba(99, 102, 241, 0.25);
-    background: linear-gradient(135deg, rgba(248, 250, 255, 0.92), rgba(255, 255, 255, 0.85));
-    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    width: 100%;
+    border-radius: 12px;
+    border: 1px solid rgba(112, 126, 174, 0.25);
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+    background: rgba(255, 255, 255, 0.92);
+    transition: border 0.2s ease, box-shadow 0.2s ease;
 }
 
 .auth-card input:focus {
-    border-color: var(--color-primary);
-    box-shadow: 0 0 0 4px rgba(60, 109, 240, 0.16);
-    transform: translateY(-1px);
+    outline: none;
+    border-color: rgba(60, 109, 240, 0.5);
+    box-shadow: 0 0 0 4px rgba(60, 109, 240, 0.12);
 }
 
 .auth-card .button-primary {
-    height: 3.1rem;
-    font-size: 1rem;
+    height: 3rem;
     border-radius: 14px;
-    box-shadow: 0 20px 34px rgba(59, 130, 246, 0.28);
-}
-
-.auth-card .button-primary:hover {
-    transform: translateY(-2px);
+    font-size: 1rem;
+    box-shadow: 0 12px 30px rgba(60, 109, 240, 0.25);
 }
 
 .auth-card .alert {
     margin: 0;
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
+    font-size: 0.9rem;
 }
 
 .auth-card-footer {
     font-size: 0.85rem;
-    color: rgba(55, 65, 81, 0.7);
+    color: var(--color-muted);
 }
 
 .auth-card-footer a {
     font-weight: 600;
 }
 
-@media (max-width: 1100px) {
-    .auth-panel {
-        grid-template-columns: minmax(320px, 1fr) minmax(320px, 0.9fr);
-    }
-
-    .auth-showcase__cards {
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    }
-}
-
-@media (max-width: 900px) {
+@media (max-width: 960px) {
     .auth-panel {
         grid-template-columns: 1fr;
-        border-radius: 28px;
     }
 
-    .auth-sidebar {
-        order: -1;
-        padding: clamp(2.5rem, 8vw, 3.25rem);
+    .auth-visual {
+        padding: clamp(2.25rem, 10vw, 3rem);
+        border-radius: 28px 28px 0 0;
     }
 
-    .auth-showcase {
-        padding: clamp(2.25rem, 8vw, 3.1rem);
-    }
-
-    .auth-feature-chips {
-        justify-content: flex-start;
+    .auth-card {
+        padding: clamp(2rem, 8vw, 3rem);
     }
 }
 
 @media (max-width: 640px) {
     .auth-body {
-        padding: 1.5rem 1rem;
+        padding: clamp(1.5rem, 8vw, 2rem) 1.25rem;
     }
 
     .auth-wrapper {
-        margin: clamp(1.25rem, 8vw, 2rem) auto;
-        padding: 0 1rem;
+        width: 100%;
     }
 
     .auth-panel {
-        border-radius: 24px;
-    }
-
-    .auth-showcase__cards {
-        grid-template-columns: 1fr;
-    }
-
-    .auth-card {
-        padding: clamp(2.1rem, 9vw, 2.5rem);
         border-radius: 22px;
     }
 
-    .field-label {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.4rem;
+    .auth-visual {
+        gap: 1.75rem;
     }
 
-    .auth-feature-chips li {
-        width: 100%;
-        text-align: center;
+    .auth-heading h1 {
+        font-size: clamp(1.75rem, 9vw, 2.3rem);
     }
-}
 
 .layout-centered {
     display: grid;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1638,436 +1638,438 @@ textarea {
 
 /* Dashboard refresh */
 .dashboard-shell {
-    width: min(1200px, 100% - clamp(2rem, 7vw, 6rem));
-    margin: clamp(2.8rem, 7vw, 6.2rem) auto clamp(3.2rem, 8vw, 6.4rem);
+    width: min(1200px, 100% - clamp(2rem, 8vw, 8rem));
+    margin: clamp(2.8rem, 7vw, 6rem) auto clamp(3rem, 8vw, 6rem);
     display: flex;
     flex-direction: column;
-    gap: clamp(2.2rem, 5vw, 3.8rem);
+    gap: clamp(2rem, 5vw, 3.5rem);
 }
 
 .dashboard-shell > .alert {
     margin: 0;
 }
 
-.welcome-hero {
+.dashboard-hero {
     position: relative;
-    border-radius: 36px;
-    padding: clamp(2.8rem, 6vw, 4rem);
-    background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(76, 106, 255, 0.78));
-    box-shadow: 0 48px 120px rgba(15, 23, 42, 0.45);
+    border-radius: 34px;
+    padding: clamp(2.6rem, 6vw, 4rem);
+    background: linear-gradient(140deg, rgba(60, 109, 240, 0.1), rgba(60, 109, 240, 0.32)), rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(60, 109, 240, 0.12);
+    box-shadow: 0 32px 80px rgba(60, 109, 240, 0.12);
     overflow: hidden;
-    color: #e5edff;
 }
 
-.welcome-hero__glow {
+.dashboard-hero__halo {
     position: absolute;
-    inset: auto -30% -55% auto;
-    width: 520px;
-    height: 520px;
-    background: radial-gradient(circle, rgba(96, 165, 250, 0.6), transparent 70%);
-    filter: blur(2px);
-    opacity: 0.65;
-}
-
-.welcome-hero__orb {
-    position: absolute;
-    width: 280px;
-    height: 280px;
+    width: 420px;
+    height: 420px;
     border-radius: 50%;
-    mix-blend-mode: screen;
-    opacity: 0.55;
-    filter: blur(10px);
+    background: radial-gradient(circle, rgba(129, 140, 248, 0.45), transparent 70%);
+    filter: blur(6px);
+    opacity: 0.85;
+    inset: auto -35% -55% auto;
 }
 
-.welcome-hero__orb--one {
-    inset: -60px auto auto 12%;
-    background: radial-gradient(circle, rgba(34, 211, 238, 0.35), transparent 70%);
+.dashboard-hero__halo--two {
+    inset: -40% auto auto -30%;
+    width: 360px;
+    height: 360px;
+    background: radial-gradient(circle, rgba(96, 165, 250, 0.4), transparent 70%);
 }
 
-.welcome-hero__orb--two {
-    inset: auto -60px 6% auto;
-    background: radial-gradient(circle, rgba(249, 115, 22, 0.25), transparent 70%);
-}
-
-.welcome-hero__inner {
+.dashboard-hero__grid {
     position: relative;
     z-index: 1;
     display: grid;
     grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
-    gap: clamp(2.2rem, 4vw, 3.4rem);
+    gap: clamp(2rem, 4vw, 3.2rem);
     align-items: stretch;
 }
 
-.welcome-hero__copy {
+.dashboard-hero__primary {
     display: flex;
     flex-direction: column;
     gap: clamp(1.4rem, 3vw, 1.9rem);
 }
 
-.welcome-hero__badge {
-    align-self: flex-start;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.5rem 1.05rem;
-    border-radius: 999px;
-    background: rgba(148, 163, 255, 0.18);
-    color: rgba(224, 231, 255, 0.95);
-    font-size: 0.76rem;
-    letter-spacing: 0.18em;
+.dashboard-hero__eyebrow {
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
     text-transform: uppercase;
+    color: rgba(31, 41, 51, 0.65);
     font-weight: 600;
 }
 
-.welcome-hero__copy h1 {
+.dashboard-hero__title {
     margin: 0;
-    font-size: clamp(2.35rem, 5vw, 3.25rem);
-    color: #fff;
+    font-size: clamp(2.1rem, 5vw, 3rem);
+    color: #0f172a;
 }
 
-.welcome-hero__lead {
+.dashboard-hero__lead {
     margin: 0;
-    font-size: clamp(1rem, 2.3vw, 1.12rem);
-    color: rgba(226, 232, 255, 0.86);
-    line-height: 1.75;
+    font-size: clamp(1rem, 2.4vw, 1.12rem);
+    line-height: 1.7;
+    color: rgba(15, 23, 42, 0.72);
     max-width: 62ch;
 }
 
-.welcome-hero__lead strong {
-    color: #fff;
+.dashboard-hero__lead strong {
+    color: var(--color-primary-dark);
 }
 
-.welcome-hero__stats {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: clamp(1.1rem, 3vw, 1.5rem);
-}
-
-.stat-bubble {
-    position: relative;
-    border-radius: 22px;
-    padding: 1.4rem 1.5rem 1.6rem;
-    background: rgba(15, 23, 42, 0.38);
-    border: 1px solid rgba(148, 163, 255, 0.2);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 22px 45px rgba(15, 23, 42, 0.4);
-    display: grid;
-    gap: 0.55rem;
-}
-
-.stat-bubble--accent {
-    background: linear-gradient(150deg, rgba(37, 99, 235, 0.85), rgba(79, 70, 229, 0.75));
-    border-color: rgba(191, 219, 254, 0.35);
-}
-
-.stat-bubble__label {
-    font-size: 0.75rem;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: rgba(226, 232, 255, 0.7);
-    font-weight: 600;
-}
-
-.stat-bubble__value {
-    font-size: 2.05rem;
-    font-weight: 700;
-    color: #fff;
-}
-
-.stat-bubble__meta {
-    font-size: 0.92rem;
-    color: rgba(226, 232, 255, 0.78);
-}
-
-.stat-bubble__progress {
-    position: relative;
-    height: 6px;
-    border-radius: 999px;
-    background: rgba(226, 232, 255, 0.2);
-    overflow: hidden;
-}
-
-.stat-bubble__progress span {
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: linear-gradient(90deg, rgba(59, 130, 246, 0.9), rgba(129, 140, 248, 0.95));
-}
-
-.welcome-hero__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.9rem;
-}
-
-.welcome-hero__actions .button-primary {
-    box-shadow: 0 16px 35px rgba(59, 130, 246, 0.45);
-}
-
-.welcome-hero__actions .button-secondary {
-    color: #0b1220;
-    background: #fff;
-    border: none;
-}
-
-.welcome-hero__actions .button-link {
-    color: rgba(224, 231, 255, 0.9);
-}
-
-.welcome-hero__panels {
-    display: grid;
-    gap: 1.4rem;
-}
-
-.welcome-panel {
-    background: rgba(255, 255, 255, 0.92);
-    border-radius: 26px;
-    padding: clamp(1.6rem, 3vw, 2.1rem);
-    box-shadow: 0 32px 70px rgba(15, 23, 42, 0.22);
-    display: grid;
-    gap: 1.1rem;
-    color: #0b1220;
-}
-
-.welcome-panel__badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    padding: 0.45rem 0.9rem;
-    border-radius: 999px;
-    background: rgba(59, 130, 246, 0.12);
-    color: #3b82f6;
-    font-size: 0.75rem;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    font-weight: 600;
-}
-
-.welcome-panel h2 {
-    margin: 0;
-    font-size: 1.4rem;
-    color: #111827;
-}
-
-.welcome-panel p {
-    margin: 0;
-    color: rgba(17, 24, 39, 0.72);
-    line-height: 1.6;
-}
-
-.ai-config__list {
-    display: grid;
-    gap: 0.8rem;
-    margin: 0;
-}
-
-.ai-config__list div {
-    display: flex;
-    justify-content: space-between;
-    gap: 0.9rem;
-    font-size: 0.96rem;
-}
-
-.ai-config__list dt {
-    font-weight: 500;
-    color: rgba(17, 24, 39, 0.6);
-}
-
-.ai-config__list dd {
-    margin: 0;
-    font-weight: 600;
-    color: #0b1220;
-    text-align: right;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 220px;
-}
-
-.welcome-panel__cta {
-    justify-self: flex-start;
-}
-
-.welcome-panel__hint {
-    font-size: 0.88rem;
-    color: rgba(17, 24, 39, 0.55);
-}
-
-.spotlight-meta {
+.dashboard-hero__metrics {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.75rem;
-    font-size: 0.96rem;
-    color: rgba(17, 24, 39, 0.75);
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: clamp(1rem, 3vw, 1.4rem);
 }
 
-.spotlight-meta span {
-    display: block;
-    font-size: 0.78rem;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: rgba(17, 24, 39, 0.5);
-    margin-bottom: 0.25rem;
-}
-
-.spotlight-meta strong {
-    font-weight: 600;
-    color: #111827;
-}
-
-.welcome-panel__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.8rem;
-}
-
-.welcome-panel__actions .button-link {
-    color: var(--color-primary);
-}
-
-.dashboard-panels {
+.metric-card {
     display: flex;
     flex-direction: column;
-    gap: 1.8rem;
+    gap: 0.55rem;
+    padding: 1.2rem 1.3rem;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(60, 109, 240, 0.12);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(6px);
 }
 
-.panels-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
-    gap: clamp(1.8rem, 4vw, 2.8rem);
+.metric-card--accent {
+    background: linear-gradient(150deg, rgba(96, 165, 250, 0.22), rgba(60, 109, 240, 0.3));
+    border-color: rgba(60, 109, 240, 0.22);
 }
 
-.panel {
-    background: rgba(255, 255, 255, 0.96);
-    border-radius: 28px;
-    padding: clamp(1.8rem, 3vw, 2.3rem);
-    box-shadow: 0 32px 70px rgba(15, 23, 42, 0.16);
+.metric-card__top {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.metric-card__label {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: rgba(15, 23, 42, 0.55);
+    font-weight: 600;
+}
+
+.metric-card__value {
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.metric-card__progress {
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(60, 109, 240, 0.14);
+    overflow: hidden;
+}
+
+.metric-card__progress span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(120deg, rgba(129, 140, 248, 0.8), rgba(59, 130, 246, 0.9));
+}
+
+.metric-card__meta {
+    font-size: 0.88rem;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.dashboard-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+    align-items: center;
+}
+
+.dashboard-hero__secondary {
     display: grid;
+    gap: 1.2rem;
+    align-content: flex-start;
+}
+
+.dashboard-card {
+    display: grid;
+    gap: 1rem;
+    padding: 1.6rem 1.7rem;
+    border-radius: 22px;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(60, 109, 240, 0.12);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.1);
+}
+
+.dashboard-card--ai {
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(226, 232, 255, 0.72));
+}
+
+.dashboard-card__eyebrow {
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(15, 23, 42, 0.55);
+    font-weight: 600;
+}
+
+.dashboard-card__title {
+    margin: 0;
+    font-size: 1.35rem;
+    color: #0f172a;
+}
+
+.dashboard-card__list {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0;
+}
+
+.dashboard-card__list div {
+    display: grid;
+    gap: 0.25rem;
+}
+
+.dashboard-card__list dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: rgba(15, 23, 42, 0.5);
+}
+
+.dashboard-card__list dd {
+    margin: 0;
+    font-weight: 600;
+    color: #111827;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dashboard-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.dashboard-card__hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(15, 23, 42, 0.62);
+}
+
+.spotlight-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.85rem;
+}
+
+.spotlight-list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.95rem;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.spotlight-list strong {
+    color: #0f172a;
+}
+
+.dashboard-overview {
+    display: flex;
+    flex-direction: column;
     gap: 1.6rem;
 }
 
-.panel__header {
+.dashboard-section__header {
+    display: grid;
+    gap: 0.6rem;
+    max-width: 640px;
+}
+
+.dashboard-section__header h2 {
+    margin: 0;
+    font-size: 1.65rem;
+    color: #0f172a;
+}
+
+.dashboard-section__header p {
+    margin: 0;
+    font-size: 0.98rem;
+    color: rgba(15, 23, 42, 0.65);
+}
+
+.overview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(1rem, 3vw, 1.5rem);
+}
+
+.overview-card {
+    border-radius: 20px;
+    padding: 1.6rem 1.8rem;
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(235, 240, 255, 0.92));
+    border: 1px solid rgba(60, 109, 240, 0.12);
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 0.7rem;
+}
+
+.overview-card__icon {
+    font-size: 1.6rem;
+}
+
+.overview-card h3 {
+    margin: 0;
+    font-size: 1.15rem;
+    color: #0f172a;
+}
+
+.overview-card p {
+    margin: 0;
+    color: rgba(15, 23, 42, 0.62);
+    line-height: 1.6;
+}
+
+.dashboard-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
+    gap: clamp(1.6rem, 4vw, 2.6rem);
+    align-items: start;
+}
+
+.module-card {
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 26px;
+    padding: clamp(1.8rem, 3vw, 2.4rem);
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.12);
+    border: 1px solid rgba(60, 109, 240, 0.12);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.module-card__header {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
 }
 
-.panel__header h2 {
+.module-card__header h2 {
     margin: 0;
-    font-size: 1.5rem;
+    font-size: 1.45rem;
     color: #0f172a;
 }
 
-.panel__description {
+.module-card__description {
     margin: 0.4rem 0 0;
     font-size: 0.95rem;
-    color: rgba(15, 23, 42, 0.64);
+    color: rgba(15, 23, 42, 0.65);
 }
 
-.panel__header .button-link {
-    align-self: center;
-}
-
-.empty-block {
+.empty-state {
     text-align: center;
     display: grid;
-    gap: 0.9rem;
-    padding: 2.5rem 1.9rem;
+    gap: 0.85rem;
+    padding: 2.4rem 1.6rem;
     border-radius: 22px;
-    background: rgba(248, 250, 252, 0.9);
-    border: 1px dashed rgba(148, 163, 255, 0.3);
+    background: rgba(243, 246, 255, 0.6);
+    border: 1px dashed rgba(60, 109, 240, 0.25);
 }
 
-.empty-block h3 {
+.empty-state h3 {
     margin: 0;
     font-size: 1.2rem;
 }
 
-.empty-block p {
+.empty-state p {
     margin: 0;
     color: rgba(15, 23, 42, 0.62);
 }
 
-.survey-cards {
+.survey-list {
     display: grid;
-    gap: 1.1rem;
+    gap: 1rem;
 }
 
-.survey-card {
-    border-radius: 22px;
-    border: 1px solid rgba(148, 163, 255, 0.22);
-    background: linear-gradient(160deg, rgba(248, 250, 252, 0.92), rgba(255, 255, 255, 0.95));
-    box-shadow: 0 22px 48px rgba(15, 23, 42, 0.12);
-    padding: 1.35rem 1.5rem;
+.survey-item {
     display: grid;
-    gap: 1.1rem;
+    gap: 1rem;
+    padding: 1.4rem 1.5rem;
+    border-radius: 20px;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.07);
 }
 
-.survey-card__top {
+.survey-item__header {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: 1.1rem;
+    gap: 1rem;
 }
 
-.survey-card__title {
+.survey-item__header h3 {
     margin: 0;
-    font-size: 1.2rem;
+    font-size: 1.18rem;
     color: #0f172a;
 }
 
-.survey-card__category {
+.survey-item__meta {
     display: inline-block;
     margin-top: 0.35rem;
     font-size: 0.83rem;
     color: rgba(15, 23, 42, 0.55);
 }
 
-.survey-card__meta {
+.survey-item__dates {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.9rem;
     margin: 0;
 }
 
-.survey-card__meta div {
+.survey-item__dates div {
     display: grid;
-    gap: 0.35rem;
+    gap: 0.25rem;
 }
 
-.survey-card__meta dt {
-    font-size: 0.78rem;
+.survey-item__dates dt {
+    font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
     color: rgba(15, 23, 42, 0.5);
 }
 
-.survey-card__meta dd {
+.survey-item__dates dd {
     margin: 0;
     font-weight: 600;
     color: #0f172a;
 }
 
-.survey-card__actions {
+.survey-item__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.9rem;
+    gap: 0.75rem;
 }
 
-.quick-actions {
+.dashboard-sidebar {
     display: grid;
-    gap: 1.2rem;
+    gap: 1.5rem;
 }
 
-.quick-actions h2 {
-    margin: 0;
-    font-size: 1.3rem;
-    color: #0f172a;
-}
-
-.quick-actions ul {
+.action-list {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -2075,52 +2077,90 @@ textarea {
     gap: 1rem;
 }
 
-.quick-actions li {
+.action-list__item {
     display: grid;
     grid-template-columns: auto 1fr;
     gap: 0.9rem;
-    align-items: start;
-    padding: 1.1rem 1.25rem;
-    border-radius: 20px;
-    background: rgba(248, 250, 252, 0.94);
+    align-items: flex-start;
+    padding: 1.1rem 1.2rem;
+    border-radius: 18px;
     border: 1px solid rgba(226, 232, 240, 0.8);
-    box-shadow: 0 20px 42px rgba(15, 23, 42, 0.08);
+    background: rgba(247, 249, 255, 0.95);
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.quick-actions__icon {
-    font-size: 1.55rem;
+.action-list__item:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 22px 42px rgba(15, 23, 42, 0.12);
+}
+
+.action-list__item.is-disabled {
+    opacity: 0.65;
+    pointer-events: none;
+}
+
+.action-list__icon {
+    font-size: 1.5rem;
     line-height: 1;
 }
 
-.quick-actions li strong {
-    font-size: 1rem;
+.action-list__body strong {
+    font-size: 1.02rem;
     color: #111827;
 }
 
-.quick-actions li p {
+.action-list__body p {
     margin: 0.35rem 0 0;
-    font-size: 0.94rem;
+    font-size: 0.92rem;
     color: rgba(17, 24, 39, 0.6);
 }
 
-.support-callout {
-    border-radius: 20px;
-    padding: 1.5rem 1.6rem;
-    background: linear-gradient(140deg, rgba(224, 231, 255, 0.45), rgba(191, 219, 254, 0.65));
-    border: 1px solid rgba(148, 163, 255, 0.35);
-    display: grid;
-    gap: 0.6rem;
+.action-list__hint {
+    display: inline-block;
+    margin-top: 0.5rem;
+    font-size: 0.82rem;
+    color: rgba(17, 24, 39, 0.55);
+}
+
+.support-card {
+    background: linear-gradient(150deg, rgba(224, 231, 255, 0.55), rgba(199, 210, 254, 0.7));
+    gap: 0.8rem;
+}
+
+.support-card h2 {
+    margin: 0;
+    font-size: 1.25rem;
     color: #0f172a;
 }
 
-.support-callout strong {
-    font-size: 1.05rem;
-}
-
-.support-callout p {
+.support-card p {
     margin: 0;
     color: rgba(15, 23, 42, 0.65);
     line-height: 1.6;
+}
+
+.support-card .button-secondary {
+    justify-content: center;
+    align-self: flex-start;
+}
+
+.support-card__meta {
+    font-size: 0.9rem;
+    color: rgba(15, 23, 42, 0.55);
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    background: rgba(60, 109, 240, 0.12);
+    color: var(--color-primary);
+    text-transform: capitalize;
 }
 
 @media (max-width: 1180px) {
@@ -2129,53 +2169,49 @@ textarea {
     }
 }
 
-@media (max-width: 1040px) {
-    .welcome-hero__inner {
+@media (max-width: 1080px) {
+    .dashboard-hero__grid {
         grid-template-columns: 1fr;
     }
 
-    .welcome-hero__panels {
+    .dashboard-hero__secondary {
         grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     }
 
-    .panels-grid {
+    .dashboard-main {
         grid-template-columns: 1fr;
     }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 780px) {
     .dashboard-shell {
         width: calc(100% - 2.4rem);
         margin: 1.8rem auto 3.5rem;
     }
 
-    .welcome-hero {
+    .dashboard-hero {
         border-radius: 28px;
         padding: 2.4rem 2rem;
     }
 
-    .welcome-hero__actions {
+    .dashboard-hero__actions,
+    .survey-item__actions {
         flex-direction: column;
         align-items: stretch;
     }
 
-    .survey-card__actions {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .welcome-panel,
-    .panel {
-        border-radius: 24px;
+    .dashboard-card,
+    .module-card {
+        border-radius: 22px;
     }
 }
 
-@media (max-width: 520px) {
-    .quick-actions li {
+@media (max-width: 560px) {
+    .dashboard-hero__metrics {
         grid-template-columns: 1fr;
     }
 
-    .welcome-hero__stats {
+    .action-list__item {
         grid-template-columns: 1fr;
     }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -723,114 +723,127 @@ textarea {
 
 .survey-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 1.75rem;
+    margin-top: 1.5rem;
 }
 
 .survey-card {
-    background: rgba(255, 255, 255, 0.95);
-    border-radius: 20px;
-    border: 1px solid rgba(148, 163, 184, 0.25);
-    padding: 1.75rem;
-    box-shadow: 0 14px 38px rgba(15, 23, 42, 0.12);
-    display: grid;
-    gap: 1.5rem;
-    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
     position: relative;
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    padding: 1.9rem;
+    display: grid;
+    gap: 1.35rem;
+    box-shadow: 0 16px 44px rgba(15, 23, 42, 0.12);
     overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
-.survey-card::after {
+.survey-card::before {
     content: '';
     position: absolute;
-    inset: -45% 45% auto auto;
-    width: 220px;
-    height: 220px;
-    background: radial-gradient(circle, rgba(60, 109, 240, 0.18), transparent 65%);
+    inset: -40% -55% auto auto;
+    width: 300px;
+    height: 300px;
+    background: radial-gradient(circle, rgba(60, 109, 240, 0.2), transparent 70%);
     opacity: 0;
-    transition: opacity 0.25s ease;
+    transition: opacity 0.3s ease;
 }
 
 .survey-card:hover {
     transform: translateY(-6px);
-    border-color: rgba(60, 109, 240, 0.35);
-    box-shadow: 0 24px 44px rgba(15, 23, 42, 0.18);
+    border-color: rgba(60, 109, 240, 0.4);
+    box-shadow: 0 28px 52px rgba(15, 23, 42, 0.18);
 }
 
-.survey-card:hover::after {
+.survey-card:hover::before {
     opacity: 1;
+}
+
+.survey-card__progress {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 4px;
+    width: 100%;
+    background: rgba(148, 163, 184, 0.25);
+}
+
+.survey-card__progress::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    width: var(--progress, 0%);
+    background: linear-gradient(90deg, rgba(60, 109, 240, 0.95), rgba(92, 132, 252, 0.75));
+    border-radius: 999px;
 }
 
 .survey-card__body {
     display: grid;
-    gap: 1rem;
+    gap: 1.1rem;
+    position: relative;
+    z-index: 1;
 }
 
 .survey-card__header {
-    display: grid;
-    gap: 0.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.85rem;
+    flex-wrap: wrap;
 }
 
 .survey-card__title {
     margin: 0;
-    font-size: clamp(1.2rem, 3vw, 1.5rem);
+    font-size: clamp(1.25rem, 3.2vw, 1.55rem);
     color: var(--color-text);
 }
 
-.survey-card__status {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-    font-size: 0.85rem;
-    color: var(--color-muted);
-}
-
-.survey-card__status-date {
-    font-size: 0.8rem;
-    color: var(--color-muted);
+.survey-card__timestamp {
+    font-size: 0.82rem;
+    color: rgba(31, 41, 51, 0.55);
 }
 
 .survey-card__description {
-    color: rgba(31, 41, 51, 0.7);
+    color: rgba(31, 41, 51, 0.72);
     margin: 0;
     font-size: 0.98rem;
-    line-height: 1.55;
+    line-height: 1.58;
 }
 
-.survey-meta {
+.survey-card__meta {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.75rem 1.25rem;
-    padding: 1.25rem;
-    border-radius: 14px;
-    background: rgba(60, 109, 240, 0.05);
+    gap: 1rem 1.25rem;
 }
 
-.survey-meta dt {
-    font-size: 0.75rem;
+.survey-card__meta dt {
+    font-size: 0.74rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--color-muted);
+    color: rgba(31, 41, 51, 0.55);
     margin-bottom: 0.25rem;
 }
 
-.survey-meta dd {
+.survey-card__meta dd {
     margin: 0;
     font-weight: 600;
+    color: var(--color-text);
 }
 
 .survey-card__footer {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    flex-wrap: wrap;
     gap: 0.9rem;
+    flex-wrap: wrap;
     border-top: 1px solid rgba(148, 163, 184, 0.25);
     padding-top: 1.1rem;
 }
 
-.survey-card__chips {
+.survey-card__badges {
     display: flex;
     flex-wrap: wrap;
     gap: 0.55rem;
@@ -1024,22 +1037,20 @@ textarea {
     .hero-card__sidebar {
         order: -1;
     }
+
+    .surveys-hero__layout {
+        grid-template-columns: 1fr;
+    }
+
+    .surveys-hero__ai {
+        justify-content: flex-start;
+    }
 }
 
 @media (max-width: 768px) {
     .top-nav {
         flex-direction: column;
         gap: 1rem;
-        align-items: flex-start;
-    }
-
-    .page-hero {
-        margin-bottom: -1.5rem;
-        padding: 3rem 0 2.5rem;
-    }
-
-    .page-hero__content {
-        flex-direction: column;
         align-items: flex-start;
     }
 
@@ -1057,30 +1068,289 @@ textarea {
         padding: 1.5rem;
     }
 
-    .insight-grid {
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-        gap: 1rem;
-    }
-
-    .insight-card__value {
-        font-size: 1.6rem;
-    }
-
-    .survey-meta {
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    }
-
     .survey-card__footer {
         flex-direction: column;
         align-items: stretch;
-    }
-
-    .survey-card__chips {
-        justify-content: flex-start;
     }
 
     .survey-card__actions {
         width: 100%;
         justify-content: flex-start;
     }
+
+    .surveys-hero {
+        padding: 2.5rem 0 2rem;
+    }
+
+    .surveys-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .surveys-toolbar__filters {
+        justify-content: flex-start;
+    }
+
+    .surveys-hero__metrics {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+
+    .metric-card__value {
+        font-size: 1.8rem;
+    }
+
+    .survey-card__meta {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+}
+.page--surveys {
+    background: radial-gradient(circle at top, rgba(60, 109, 240, 0.08), transparent 55%), var(--color-bg);
+}
+
+.surveys-hero {
+    position: relative;
+    padding: 3.5rem 0 2.5rem;
+}
+
+.surveys-hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.surveys-hero .container {
+    display: grid;
+    gap: 2.5rem;
+}
+
+.surveys-hero__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+    gap: 2.5rem;
+    align-items: stretch;
+}
+
+.surveys-hero__intro {
+    display: grid;
+    gap: 1.2rem;
+}
+
+.surveys-hero__subtitle {
+    margin: 0;
+    font-size: 1.05rem;
+    color: rgba(31, 41, 51, 0.7);
+    max-width: 540px;
+}
+
+.surveys-hero__actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.surveys-hero__ai {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.ai-card {
+    background: linear-gradient(165deg, rgba(60, 109, 240, 0.15), rgba(255, 255, 255, 0.9));
+    border-radius: 20px;
+    padding: 1.6rem;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    display: grid;
+    gap: 1.1rem;
+    min-width: 260px;
+}
+
+.ai-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.ai-card__title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.ai-card__meta {
+    display: grid;
+    gap: 0.8rem;
+}
+
+.ai-card__meta dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(31, 41, 51, 0.55);
+    margin-bottom: 0.2rem;
+}
+
+.ai-card__meta dd {
+    margin: 0;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.ai-card__link {
+    font-weight: 600;
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+.ai-card__link:hover {
+    text-decoration: underline;
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.status-badge--active {
+    background: rgba(34, 197, 94, 0.18);
+    color: #15803d;
+}
+
+.status-badge--inactive {
+    background: rgba(217, 48, 37, 0.15);
+    color: var(--color-danger);
+}
+
+.surveys-hero__metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.metric-card {
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: 18px;
+    padding: 1.25rem 1.35rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 0.65rem;
+}
+
+.metric-card__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(31, 41, 51, 0.55);
+    font-weight: 700;
+}
+
+.metric-card__value {
+    font-size: clamp(1.9rem, 4vw, 2.4rem);
+    color: var(--color-text);
+    margin: 0;
+}
+
+.metric-card__hint {
+    font-size: 0.82rem;
+    color: rgba(31, 41, 51, 0.6);
+}
+
+.surveys-toolbar {
+    margin-top: 2rem;
+    padding: 1.1rem 1.25rem;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.surveys-toolbar__filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.16);
+    color: rgba(31, 41, 51, 0.65);
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.filter-chip:hover {
+    transform: translateY(-1px);
+    background: rgba(60, 109, 240, 0.16);
+    color: var(--color-primary);
+}
+
+.filter-chip.is-active {
+    background: rgba(60, 109, 240, 0.18);
+    color: var(--color-primary);
+    box-shadow: 0 10px 20px rgba(60, 109, 240, 0.18);
+}
+
+.filter-chip__count {
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.85);
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.surveys-toolbar__context {
+    font-size: 0.85rem;
+    color: rgba(31, 41, 51, 0.65);
+}
+
+.toolbar-hint {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.toolbar-hint::before {
+    content: '•';
+    color: rgba(60, 109, 240, 0.65);
+}
+
+.no-results {
+    margin-top: 1.5rem;
+    font-size: 0.95rem;
+    color: rgba(31, 41, 51, 0.65);
+}
+
+.settings-grid {
+    display: grid;
+    gap: 2rem;
+    margin-bottom: 2.5rem;
+}
+
+.form-actions--sticky {
+    display: flex;
+    justify-content: flex-end;
+    padding: 1rem 0 0;
+    position: sticky;
+    bottom: 1.5rem;
+    background: linear-gradient(180deg, rgba(245, 246, 251, 0), rgba(245, 246, 251, 0.95));
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1637,121 +1637,163 @@ textarea {
 }
 
 /* Dashboard refresh */
-.dashboard {
-    max-width: 1200px;
-    margin: clamp(1.5rem, 5vw, 3.5rem) auto 4rem;
-    padding: 0 clamp(1.25rem, 4vw, 2.75rem);
+.dashboard-shell {
+    width: min(1180px, 100% - clamp(2rem, 7vw, 6rem));
+    margin: clamp(2.5rem, 6vw, 5rem) auto clamp(3rem, 7vw, 6rem);
     display: flex;
     flex-direction: column;
-    gap: clamp(2rem, 4vw, 3rem);
+    gap: clamp(2rem, 5vw, 3.5rem);
+}
+
+.dashboard-shell > .alert {
+    margin: 0;
 }
 
 .dashboard-hero {
     position: relative;
-    border-radius: 28px;
-    padding: clamp(2rem, 4vw, 3.25rem);
-    background: radial-gradient(circle at top left, rgba(60, 109, 240, 0.18), transparent 45%),
-        radial-gradient(circle at bottom right, rgba(35, 197, 255, 0.16), transparent 55%),
-        linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(247, 250, 255, 0.9));
-    box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+    border-radius: 32px;
+    padding: clamp(2.5rem, 5vw, 3.75rem);
+    background: radial-gradient(circle at 15% 20%, rgba(60, 109, 240, 0.2), transparent 45%),
+        radial-gradient(circle at 85% 15%, rgba(34, 211, 238, 0.14), transparent 55%),
+        linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(243, 247, 255, 0.92));
+    box-shadow: 0 38px 80px rgba(15, 23, 42, 0.16);
     overflow: hidden;
+}
+
+.dashboard-hero::before {
+    content: '';
+    position: absolute;
+    inset: 12% auto -45% 58%;
+    width: 420px;
+    height: 420px;
+    background: radial-gradient(circle, rgba(60, 109, 240, 0.35), transparent 65%);
+    filter: blur(8px);
+    opacity: 0.55;
+    pointer-events: none;
 }
 
 .dashboard-hero::after {
     content: '';
     position: absolute;
-    inset: 12% -30% -40% auto;
-    width: 360px;
-    height: 360px;
-    background: radial-gradient(circle, rgba(60, 109, 240, 0.35), transparent 65%);
+    inset: -40% -15% auto auto;
+    width: 420px;
+    height: 420px;
+    background: radial-gradient(circle, rgba(34, 197, 94, 0.18), transparent 70%);
     filter: blur(6px);
-    opacity: 0.6;
+    opacity: 0.4;
     pointer-events: none;
 }
 
-.dashboard-hero__inner {
+.dashboard-hero__grid {
     position: relative;
     display: grid;
     grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
-    gap: clamp(2rem, 4vw, 3rem);
-    align-items: start;
-}
-
-.dashboard-hero__intro {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    position: relative;
+    gap: clamp(2rem, 4vw, 3.2rem);
+    align-items: stretch;
     z-index: 1;
 }
 
-.dashboard-hero__eyebrow {
+.dashboard-hero__content {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.dashboard-hero__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(60, 109, 240, 0.12);
+    color: var(--color-primary-dark);
     font-size: 0.75rem;
-    letter-spacing: 0.16em;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: rgba(17, 24, 39, 0.6);
     font-weight: 600;
 }
 
-.dashboard-hero__intro h1 {
+.dashboard-hero__content h1 {
     margin: 0;
-    font-size: clamp(2.1rem, 4vw, 2.9rem);
-    color: #0f172a;
+    font-size: clamp(2.2rem, 5vw, 3.05rem);
+    color: #0b1220;
 }
 
 .dashboard-hero__lead {
     margin: 0;
     font-size: 1.05rem;
-    line-height: 1.6;
-    color: rgba(15, 23, 42, 0.72);
-    max-width: 540px;
+    line-height: 1.7;
+    color: rgba(11, 18, 32, 0.74);
+    max-width: 560px;
 }
 
-.dashboard-hero__stats {
-    display: flex;
-    flex-wrap: wrap;
+.dashboard-hero__lead strong {
+    color: #0b1220;
+}
+
+.dashboard-hero__highlights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
     gap: 1rem;
 }
 
-.hero-chip {
-    background: rgba(255, 255, 255, 0.75);
-    border-radius: 16px;
-    padding: 1rem 1.25rem;
-    box-shadow: 0 18px 40px rgba(60, 109, 240, 0.12);
+.highlight-card {
+    position: relative;
     display: grid;
-    gap: 0.45rem;
-    min-width: 200px;
+    gap: 0.4rem;
+    padding: 1.15rem 1.35rem 1.4rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.82);
+    box-shadow: 0 22px 48px rgba(60, 109, 240, 0.18);
+    backdrop-filter: blur(18px);
+    overflow: hidden;
 }
 
-.hero-chip__label {
+.highlight-card::after {
+    content: '';
+    position: absolute;
+    inset: auto 0 0 auto;
+    width: 110px;
+    height: 110px;
+    background: radial-gradient(circle at bottom right, rgba(60, 109, 240, 0.18), transparent 70%);
+    opacity: 0.5;
+    transform: translate(30%, 30%);
+}
+
+.highlight-card__label {
     font-size: 0.75rem;
+    letter-spacing: 0.14em;
     text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: rgba(15, 23, 42, 0.55);
+    color: rgba(11, 18, 32, 0.55);
     font-weight: 600;
 }
 
-.hero-chip__value {
-    font-size: 1.55rem;
+.highlight-card__value {
+    font-size: 1.65rem;
     font-weight: 700;
-    color: #0f172a;
+    color: #0b1220;
+    position: relative;
+    z-index: 1;
 }
 
-.hero-chip__meta {
-    font-size: 0.85rem;
-    color: rgba(15, 23, 42, 0.65);
+.highlight-card__meta {
+    font-size: 0.88rem;
+    color: rgba(11, 18, 32, 0.62);
+    position: relative;
+    z-index: 1;
 }
 
-.hero-chip__progress {
+.highlight-card__progress {
     position: relative;
     display: block;
     height: 6px;
     border-radius: 999px;
-    background: rgba(60, 109, 240, 0.15);
+    background: rgba(60, 109, 240, 0.16);
     overflow: hidden;
+    margin-top: 0.35rem;
 }
 
-.hero-chip__progress span {
+.highlight-card__progress span {
     display: block;
     height: 100%;
     border-radius: inherit;
@@ -1761,117 +1803,110 @@ textarea {
 .dashboard-hero__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.9rem;
 }
 
-.dashboard-hero__aside {
+.dashboard-hero__actions .button-link {
+    font-weight: 600;
+    color: rgba(11, 18, 32, 0.7);
+}
+
+.dashboard-hero__panel {
     display: grid;
-    gap: 1.5rem;
-    position: relative;
-    z-index: 1;
+    gap: 1.4rem;
 }
 
-.ai-summary {
-    background: rgba(15, 23, 42, 0.9);
-    color: #f8fafc;
-    border-radius: 22px;
-    padding: 1.5rem 1.75rem 1.75rem;
-    position: relative;
-    overflow: hidden;
-    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.35);
+.glass-card {
+    background: rgba(255, 255, 255, 0.78);
+    border-radius: 26px;
+    padding: clamp(1.5rem, 3vw, 1.9rem);
+    box-shadow: 0 26px 60px rgba(15, 23, 42, 0.16);
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.65);
+    display: grid;
+    gap: 1.1rem;
 }
 
-.ai-summary::before {
-    content: '';
-    position: absolute;
-    inset: -40% auto auto -30%;
-    width: 280px;
-    height: 280px;
-    background: radial-gradient(circle, rgba(59, 130, 246, 0.65), transparent 65%);
-    opacity: 0.5;
-}
-
-.ai-summary__badge {
+.glass-card__badge {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    border-radius: 14px;
-    background: rgba(248, 250, 252, 0.12);
-    backdrop-filter: blur(6px);
-    font-weight: 700;
-    margin-bottom: 1rem;
-}
-
-.ai-summary__body {
-    position: relative;
-    z-index: 1;
-    display: grid;
-    gap: 1rem;
-}
-
-.ai-summary__body h3 {
-    margin: 0;
-    font-size: 1.1rem;
-}
-
-.ai-summary__list {
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 0.75rem;
-}
-
-.ai-summary__list div {
-    display: grid;
-    gap: 0.2rem;
-}
-
-.ai-summary__list dt {
-    font-size: 0.8rem;
+    gap: 0.45rem;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(60, 109, 240, 0.12);
+    color: var(--color-primary-dark);
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
     text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: rgba(248, 250, 252, 0.68);
-}
-
-.ai-summary__list dd {
-    margin: 0;
     font-weight: 600;
 }
 
-.ai-summary__action {
-    align-self: flex-start;
+.glass-card h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    color: #0b1220;
 }
 
-.ai-summary__hint {
+.ai-config__list {
+    display: grid;
+    gap: 0.7rem;
+    margin: 0;
+}
+
+.ai-config__list div {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.85rem;
+    font-size: 0.95rem;
+}
+
+.ai-config__list dt {
+    font-weight: 500;
+    color: rgba(11, 18, 32, 0.55);
+}
+
+.ai-config__list dd {
+    margin: 0;
+    font-weight: 600;
+    color: #0b1220;
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 220px;
+}
+
+.ai-config__hint {
     margin: 0;
     font-size: 0.85rem;
-    color: rgba(248, 250, 252, 0.7);
+    color: rgba(11, 18, 32, 0.58);
+}
+
+.ai-config__action {
+    justify-self: start;
 }
 
 .spotlight-card {
-    background: rgba(255, 255, 255, 0.88);
-    border-radius: 20px;
-    padding: 1.5rem 1.75rem;
-    box-shadow: 0 22px 40px rgba(15, 23, 42, 0.12);
+    background: rgba(248, 250, 252, 0.88);
+    border-radius: 22px;
+    padding: 1.6rem 1.75rem;
     display: grid;
-    gap: 1rem;
+    gap: 1.1rem;
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    box-shadow: 0 20px 46px rgba(15, 23, 42, 0.1);
 }
 
 .spotlight-card__label {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
     font-size: 0.75rem;
-    letter-spacing: 0.14em;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: rgba(15, 23, 42, 0.5);
+    color: rgba(11, 18, 32, 0.55);
+    font-weight: 600;
 }
 
 .spotlight-card h3 {
     margin: 0;
-    font-size: 1.25rem;
+    font-size: 1.3rem;
 }
 
 .spotlight-card__meta {
@@ -1879,7 +1914,7 @@ textarea {
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.5rem;
+    gap: 0.55rem;
     font-size: 0.95rem;
 }
 
@@ -1887,10 +1922,15 @@ textarea {
     font-weight: 600;
 }
 
+.spotlight-card p {
+    margin: 0;
+    color: rgba(11, 18, 32, 0.62);
+}
+
 .spotlight-card__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.85rem;
 }
 
 .status-pill {
@@ -1928,131 +1968,189 @@ textarea {
     color: #b45309;
 }
 
-.insight-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.5rem;
-}
-
-.insight-card {
-    background: rgba(255, 255, 255, 0.92);
-    border-radius: 20px;
-    padding: 1.5rem 1.75rem;
-    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.1);
-    display: grid;
-    gap: 1.1rem;
-}
-
-.insight-card header {
+.dashboard-overview {
     display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.overview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    gap: 1.35rem;
+}
+
+.overview-card {
+    position: relative;
+    display: grid;
+    gap: 0.65rem;
+    padding: 1.6rem 1.7rem;
+    border-radius: 22px;
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: 0 24px 52px rgba(15, 23, 42, 0.12);
+    overflow: hidden;
+}
+
+.overview-card::before {
+    content: '';
+    position: absolute;
+    inset: auto auto -40% -10%;
+    width: 220px;
+    height: 220px;
+    background: radial-gradient(circle, rgba(60, 109, 240, 0.14), transparent 70%);
+    opacity: 0.55;
+}
+
+.overview-card__icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    display: inline-flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
+    font-size: 1.35rem;
+    background: rgba(60, 109, 240, 0.16);
+    color: var(--color-primary);
 }
 
-.insight-card__label {
-    font-size: 0.85rem;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: rgba(15, 23, 42, 0.55);
+.overview-card--success .overview-card__icon {
+    background: rgba(16, 185, 129, 0.18);
+    color: #0f766e;
 }
 
-.insight-card__value {
-    font-size: clamp(2rem, 4vw, 2.65rem);
-    font-weight: 700;
-    color: #0f172a;
-}
-
-.insight-card__hint {
-    margin: 0;
-    font-size: 0.9rem;
-    color: rgba(15, 23, 42, 0.6);
-}
-
-.insight-card__trend {
-    font-size: 0.8rem;
-    font-weight: 600;
-    padding: 0.25rem 0.55rem;
-    border-radius: 999px;
-    background: rgba(148, 163, 184, 0.16);
-    color: rgba(71, 85, 105, 0.95);
-}
-
-.trend-positive {
-    background: rgba(16, 185, 129, 0.15);
-    color: #047857;
-}
-
-.trend-warning {
+.overview-card--warning .overview-card__icon {
     background: rgba(251, 191, 36, 0.18);
     color: #b45309;
 }
 
-.dashboard-panels {
-    display: grid;
-    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
-    gap: 1.75rem;
+.overview-card__label {
+    font-size: 0.78rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(11, 18, 32, 0.58);
+    font-weight: 600;
 }
 
-.recent-surveys__list {
-    display: grid;
-    gap: 1.25rem;
+.overview-card__value {
+    font-size: 2.05rem;
+    font-weight: 700;
+    color: #0b1220;
+    margin: 0;
 }
 
-.survey-card {
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.9));
-    border-radius: 18px;
-    padding: 1.5rem 1.65rem;
-    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
-    display: grid;
-    gap: 1.25rem;
+.overview-card__hint {
+    margin: 0;
+    font-size: 0.92rem;
+    color: rgba(11, 18, 32, 0.62);
 }
 
-.survey-card__header {
+.dashboard-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
+    gap: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.dashboard-layout__aside {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.surface-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 26px;
+    padding: clamp(1.6rem, 3vw, 2.15rem);
+    box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.surface-card__header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
 }
 
-.survey-card__header h3 {
+.surface-card__header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+}
+
+.surface-card__description {
+    margin: 0;
+    color: rgba(11, 18, 32, 0.6);
+    font-size: 0.95rem;
+}
+
+.survey-list {
+    display: grid;
+    gap: 1.1rem;
+}
+
+.survey-item {
+    border: 1px solid rgba(60, 109, 240, 0.1);
+    border-radius: 20px;
+    padding: 1.25rem 1.4rem;
+    background: rgba(248, 250, 252, 0.9);
+    display: grid;
+    gap: 1rem;
+}
+
+.survey-item__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.survey-item__title {
     margin: 0;
     font-size: 1.15rem;
 }
 
-.survey-card__category {
+.survey-item__category {
     font-size: 0.85rem;
-    color: rgba(15, 23, 42, 0.55);
+    color: rgba(11, 18, 32, 0.58);
+    margin-top: 0.35rem;
 }
 
-.survey-card__meta {
+.survey-item__meta {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     gap: 1rem;
+    font-size: 0.95rem;
+    color: rgba(11, 18, 32, 0.62);
 }
 
-.survey-card__meta span {
-    font-size: 0.8rem;
+.survey-item__meta span {
+    display: block;
+    font-size: 0.78rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
-    color: rgba(15, 23, 42, 0.5);
+    color: rgba(11, 18, 32, 0.45);
+    margin-bottom: 0.2rem;
 }
 
-.survey-card__meta strong {
-    font-size: 1rem;
-    font-weight: 600;
-}
-
-.survey-card__actions {
+.survey-item__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.85rem;
 }
 
-.panel--actions .panel-body {
-    padding-top: 1rem;
+.empty-state {
+    text-align: center;
+    display: grid;
+    gap: 0.85rem;
+    padding: 2.4rem 1.75rem;
+    border-radius: 20px;
+    background: rgba(248, 250, 252, 0.95);
+}
+
+.empty-state h3 {
+    margin: 0;
 }
 
 .quick-actions-list {
@@ -2060,7 +2158,7 @@ textarea {
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 1.1rem;
+    gap: 1rem;
 }
 
 .quick-actions-list__item {
@@ -2068,10 +2166,10 @@ textarea {
     grid-template-columns: auto 1fr;
     gap: 1rem;
     align-items: start;
-    padding: 1rem 1.25rem;
-    border-radius: 16px;
+    padding: 1.05rem 1.25rem;
+    border-radius: 18px;
     background: rgba(248, 250, 252, 0.9);
-    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.06);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.07);
 }
 
 .quick-actions-list__icon {
@@ -2084,57 +2182,80 @@ textarea {
     gap: 0.45rem;
 }
 
+.quick-actions-list__content strong {
+    font-size: 1rem;
+}
+
 .quick-actions-list__content p {
     margin: 0;
     font-size: 0.95rem;
-    color: rgba(15, 23, 42, 0.65);
+    color: rgba(11, 18, 32, 0.63);
 }
 
-.empty-state {
-    text-align: center;
+.support-card {
+    background: rgba(248, 250, 252, 0.92);
+    border-radius: 20px;
+    padding: 1.4rem 1.55rem;
     display: grid;
-    gap: 0.75rem;
-    padding: 2rem 1.5rem;
-    border-radius: 18px;
-    background: rgba(248, 250, 252, 0.95);
+    gap: 0.6rem;
+    border: 1px dashed rgba(99, 102, 241, 0.3);
 }
 
-.empty-state h3 {
+.support-card strong {
+    font-size: 1.05rem;
+}
+
+.support-card p {
     margin: 0;
+    color: rgba(11, 18, 32, 0.63);
+    line-height: 1.55;
 }
 
-@media (max-width: 1080px) {
-    .dashboard-hero__inner {
+.support-card p + p {
+    margin-top: 0.4rem;
+}
+
+@media (max-width: 1180px) {
+    .dashboard-shell {
+        width: calc(100% - clamp(1.5rem, 5vw, 3rem));
+    }
+}
+
+@media (max-width: 1024px) {
+    .dashboard-hero__grid {
         grid-template-columns: 1fr;
     }
 
-    .dashboard-hero__aside {
+    .dashboard-hero__panel {
         grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
 
-    .dashboard-panels {
+    .dashboard-layout {
         grid-template-columns: 1fr;
     }
 }
 
 @media (max-width: 720px) {
-    .dashboard {
-        margin: 1.5rem auto 3rem;
-        padding: 0 1.25rem;
+    .dashboard-shell {
+        width: calc(100% - 2.5rem);
+        margin: 1.75rem auto 3.5rem;
     }
 
     .dashboard-hero {
-        border-radius: 22px;
-        padding: 2rem 1.75rem;
+        border-radius: 26px;
+        padding: 2.2rem 1.85rem;
     }
 
-    .hero-chip {
-        min-width: 0;
-        width: 100%;
-    }
-
-    .survey-card__meta {
+    .dashboard-hero__highlights {
         grid-template-columns: 1fr;
+    }
+
+    .overview-grid {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .surface-card {
+        border-radius: 22px;
     }
 
     .quick-actions-list__item {
@@ -2148,11 +2269,9 @@ textarea {
         align-items: stretch;
     }
 
-    .spotlight-card__actions {
-        flex-direction: column;
-    }
-
-    .survey-card__actions {
+    .spotlight-card__actions,
+    .survey-item__actions {
         flex-direction: column;
     }
 }
+

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -25,6 +25,14 @@ body {
     min-height: 100vh;
 }
 
+.auth-body {
+    background: linear-gradient(145deg, #e7f0ff 0%, #f9f5ff 45%, #ffffff 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(2rem, 6vw, 4rem) 1.25rem;
+}
+
 a {
     color: var(--color-primary);
     text-decoration: none;
@@ -203,6 +211,232 @@ a:hover {
 
 .button-block {
     width: 100%;
+}
+
+.auth-wrapper {
+    width: min(1100px, 100%);
+    margin: 0 auto;
+}
+
+.auth-panel {
+    display: grid;
+    grid-template-columns: minmax(320px, 1.2fr) minmax(320px, 1fr);
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 28px;
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.15);
+    overflow: hidden;
+    backdrop-filter: blur(10px);
+}
+
+.auth-hero {
+    position: relative;
+    padding: clamp(2.5rem, 6vw, 3.5rem);
+    background: linear-gradient(135deg, #1c7be4 0%, #37b7f7 50%, #64d5d5 100%);
+    color: #f6fbff;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    isolation: isolate;
+}
+
+.auth-hero::after {
+    content: '';
+    position: absolute;
+    inset: auto -50px -120px auto;
+    width: 260px;
+    height: 260px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.35), transparent 70%);
+    filter: blur(2px);
+    z-index: -1;
+}
+
+.auth-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    padding: 0.4rem 1rem;
+    align-self: flex-start;
+    backdrop-filter: blur(8px);
+}
+
+.auth-hero h1 {
+    margin: 0;
+    font-size: clamp(2rem, 4.6vw, 2.7rem);
+    line-height: 1.2;
+}
+
+.auth-hero p {
+    margin: 0;
+    font-size: 1rem;
+    color: rgba(246, 251, 255, 0.9);
+}
+
+.auth-features {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.auth-features li {
+    position: relative;
+    padding-left: 2rem;
+    font-weight: 500;
+}
+
+.auth-features li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.18);
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.55);
+}
+
+.auth-features li::after {
+    content: '';
+    position: absolute;
+    left: 0.33rem;
+    top: 50%;
+    width: 0.6rem;
+    height: 0.3rem;
+    border-left: 2px solid #fff;
+    border-bottom: 2px solid #fff;
+    transform: translateY(-60%) rotate(-45deg);
+}
+
+.auth-card {
+    background: #ffffff;
+    padding: clamp(2.5rem, 5vw, 3.25rem);
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.auth-card-header {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.auth-card-header h2 {
+    margin: 0;
+    font-size: clamp(1.5rem, 3vw, 1.75rem);
+}
+
+.auth-card-header p {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-muted);
+}
+
+.auth-form {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.form-field {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.field-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.field-action {
+    font-size: 0.85rem;
+    color: var(--color-primary);
+    font-weight: 600;
+    opacity: 0.8;
+}
+
+.field-action[aria-disabled="true"] {
+    pointer-events: none;
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.auth-card input[type="email"],
+.auth-card input[type="password"] {
+    border-radius: 12px;
+    border: 1px solid rgba(82, 103, 223, 0.25);
+    background: rgba(248, 250, 255, 0.9);
+}
+
+.auth-card input:focus {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 4px rgba(60, 109, 240, 0.15);
+}
+
+.auth-card .button-primary {
+    height: 3rem;
+    font-size: 1rem;
+    border-radius: 12px;
+    box-shadow: 0 18px 30px rgba(60, 109, 240, 0.3);
+}
+
+.auth-card .button-primary:hover {
+    transform: translateY(-2px);
+}
+
+.auth-card .alert {
+    margin-bottom: 0;
+}
+
+@media (max-width: 960px) {
+    .auth-panel {
+        grid-template-columns: 1fr;
+    }
+
+    .auth-hero {
+        padding: 2.5rem;
+    }
+
+    .auth-card {
+        padding: 2.25rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .auth-body {
+        padding: 1.5rem 1rem;
+    }
+
+    .auth-panel {
+        border-radius: 22px;
+    }
+
+    .auth-hero {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        padding: 2rem 1.75rem;
+    }
+
+    .auth-card {
+        padding: 2rem 1.75rem 1.75rem;
+    }
+
+    .field-label {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+    }
 }
 
 .layout-centered {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -213,114 +213,156 @@ a:hover {
     width: 100%;
 }
 
+
 .auth-wrapper {
-    width: min(1100px, 100%);
-    margin: 0 auto;
+    width: min(1180px, 100%);
+    margin: clamp(1.5rem, 5vw, 3rem) auto;
+    padding: 0 clamp(1rem, 4vw, 2rem);
 }
 
 .auth-panel {
-    display: grid;
-    grid-template-columns: minmax(320px, 1.2fr) minmax(320px, 1fr);
-    background: rgba(255, 255, 255, 0.96);
-    border-radius: 28px;
-    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.15);
-    overflow: hidden;
-    backdrop-filter: blur(10px);
-}
-
-.auth-hero {
     position: relative;
-    padding: clamp(2.5rem, 6vw, 3.5rem);
-    background: linear-gradient(135deg, #1c7be4 0%, #37b7f7 50%, #64d5d5 100%);
-    color: #f6fbff;
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
+    display: grid;
+    grid-template-columns: minmax(340px, 1.05fr) minmax(320px, 0.8fr);
+    background: rgba(255, 255, 255, 0.88);
+    border-radius: 32px;
+    box-shadow: 0 32px 60px rgba(15, 23, 42, 0.14);
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.65);
+    backdrop-filter: blur(18px);
     isolation: isolate;
 }
 
-.auth-hero::after {
+.auth-panel::before,
+.auth-panel::after {
     content: '';
     position: absolute;
-    inset: auto -50px -120px auto;
-    width: 260px;
-    height: 260px;
-    background: radial-gradient(circle, rgba(255, 255, 255, 0.35), transparent 70%);
-    filter: blur(2px);
+    border-radius: 50%;
+    filter: blur(0);
     z-index: -1;
 }
 
-.auth-badge {
+.auth-panel::before {
+    width: 420px;
+    height: 420px;
+    inset: -28% auto auto -22%;
+    background: radial-gradient(circle, rgba(91, 138, 255, 0.22), transparent 70%);
+}
+
+.auth-panel::after {
+    width: 360px;
+    height: 360px;
+    inset: auto -25% -35% auto;
+    background: radial-gradient(circle, rgba(79, 70, 229, 0.18), transparent 70%);
+}
+
+.auth-showcase {
+    position: relative;
+    padding: clamp(2.75rem, 6vw, 3.75rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.75rem, 4vw, 2.75rem);
+    background: linear-gradient(160deg, rgba(59, 130, 246, 0.18) 0%, rgba(79, 70, 229, 0.14) 35%, rgba(14, 165, 233, 0.12) 100%);
+}
+
+.auth-showcase__header {
+    display: grid;
+    gap: 1rem;
+    max-width: 520px;
+}
+
+.auth-eyebrow {
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.4rem;
     font-size: 0.75rem;
     text-transform: uppercase;
-    letter-spacing: 0.2em;
+    letter-spacing: 0.22em;
     font-weight: 600;
-    background: rgba(255, 255, 255, 0.18);
-    border-radius: 999px;
-    padding: 0.4rem 1rem;
-    align-self: flex-start;
-    backdrop-filter: blur(8px);
+    color: rgba(17, 24, 39, 0.7);
 }
 
-.auth-hero h1 {
+.auth-showcase h1 {
     margin: 0;
-    font-size: clamp(2rem, 4.6vw, 2.7rem);
-    line-height: 1.2;
+    font-size: clamp(2.2rem, 4.8vw, 2.9rem);
+    line-height: 1.15;
+    color: #0f172a;
 }
 
-.auth-hero p {
+.auth-showcase p {
     margin: 0;
     font-size: 1rem;
-    color: rgba(246, 251, 255, 0.9);
+    color: rgba(15, 23, 42, 0.7);
 }
 
-.auth-features {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+.auth-showcase__cards {
     display: grid;
-    gap: 0.75rem;
+    grid-template-columns: repeat(3, minmax(140px, 1fr));
+    gap: 1.25rem;
 }
 
-.auth-features li {
-    position: relative;
-    padding-left: 2rem;
-    font-weight: 500;
+.auth-insight {
+    display: grid;
+    gap: 0.45rem;
+    padding: 1.4rem 1.6rem;
+    border-radius: 22px;
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.82), rgba(231, 240, 255, 0.9));
+    border: 1px solid rgba(203, 213, 225, 0.4);
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
+    backdrop-filter: blur(10px);
 }
 
-.auth-features li::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 1.25rem;
-    height: 1.25rem;
+.auth-insight__value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #1d4ed8;
+}
+
+.auth-insight__title {
+    margin: 0;
+    font-size: 1.05rem;
+    color: #0f172a;
+}
+
+.auth-insight__text {
+    margin: 0;
+    font-size: 0.9rem;
+    color: rgba(15, 23, 42, 0.65);
+}
+
+.auth-feature-chips {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin: 0;
+    padding: 0;
+}
+
+.auth-feature-chips li {
+    padding: 0.55rem 1.1rem;
     border-radius: 999px;
-    display: inline-flex;
+    background: rgba(15, 23, 42, 0.08);
+    color: rgba(15, 23, 42, 0.75);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.auth-sidebar {
+    position: relative;
+    display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(255, 255, 255, 0.18);
-    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.55);
-}
-
-.auth-features li::after {
-    content: '';
-    position: absolute;
-    left: 0.33rem;
-    top: 50%;
-    width: 0.6rem;
-    height: 0.3rem;
-    border-left: 2px solid #fff;
-    border-bottom: 2px solid #fff;
-    transform: translateY(-60%) rotate(-45deg);
+    padding: clamp(3rem, 7vw, 4rem);
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.02) 0%, rgba(59, 130, 246, 0.05) 100%);
 }
 
 .auth-card {
+    width: min(420px, 100%);
     background: #ffffff;
+    border-radius: 26px;
+    border: 1px solid rgba(229, 231, 235, 0.8);
+    box-shadow: 0 28px 45px rgba(30, 64, 175, 0.18);
     padding: clamp(2.5rem, 5vw, 3.25rem);
     display: flex;
     flex-direction: column;
@@ -329,28 +371,29 @@ a:hover {
 
 .auth-card-header {
     display: grid;
-    gap: 0.5rem;
+    gap: 0.6rem;
 }
 
 .auth-card-header h2 {
     margin: 0;
-    font-size: clamp(1.5rem, 3vw, 1.75rem);
+    font-size: clamp(1.6rem, 3.2vw, 1.85rem);
+    color: #111827;
 }
 
 .auth-card-header p {
     margin: 0;
     font-size: 0.95rem;
-    color: var(--color-muted);
+    color: rgba(55, 65, 81, 0.85);
 }
 
 .auth-form {
     display: grid;
-    gap: 1.25rem;
+    gap: 1.35rem;
 }
 
 .form-field {
     display: grid;
-    gap: 0.5rem;
+    gap: 0.6rem;
 }
 
 .field-label {
@@ -363,32 +406,35 @@ a:hover {
     font-size: 0.85rem;
     color: var(--color-primary);
     font-weight: 600;
-    opacity: 0.8;
+    opacity: 0.85;
 }
 
 .field-action[aria-disabled="true"] {
     pointer-events: none;
     cursor: not-allowed;
-    opacity: 0.5;
+    opacity: 0.45;
 }
 
 .auth-card input[type="email"],
 .auth-card input[type="password"] {
-    border-radius: 12px;
-    border: 1px solid rgba(82, 103, 223, 0.25);
-    background: rgba(248, 250, 255, 0.9);
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(99, 102, 241, 0.25);
+    background: linear-gradient(135deg, rgba(248, 250, 255, 0.92), rgba(255, 255, 255, 0.85));
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .auth-card input:focus {
     border-color: var(--color-primary);
-    box-shadow: 0 0 0 4px rgba(60, 109, 240, 0.15);
+    box-shadow: 0 0 0 4px rgba(60, 109, 240, 0.16);
+    transform: translateY(-1px);
 }
 
 .auth-card .button-primary {
-    height: 3rem;
+    height: 3.1rem;
     font-size: 1rem;
-    border-radius: 12px;
-    box-shadow: 0 18px 30px rgba(60, 109, 240, 0.3);
+    border-radius: 14px;
+    box-shadow: 0 20px 34px rgba(59, 130, 246, 0.28);
 }
 
 .auth-card .button-primary:hover {
@@ -396,20 +442,45 @@ a:hover {
 }
 
 .auth-card .alert {
-    margin-bottom: 0;
+    margin: 0;
 }
 
-@media (max-width: 960px) {
+.auth-card-footer {
+    font-size: 0.85rem;
+    color: rgba(55, 65, 81, 0.7);
+}
+
+.auth-card-footer a {
+    font-weight: 600;
+}
+
+@media (max-width: 1100px) {
+    .auth-panel {
+        grid-template-columns: minmax(320px, 1fr) minmax(320px, 0.9fr);
+    }
+
+    .auth-showcase__cards {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+}
+
+@media (max-width: 900px) {
     .auth-panel {
         grid-template-columns: 1fr;
+        border-radius: 28px;
     }
 
-    .auth-hero {
-        padding: 2.5rem;
+    .auth-sidebar {
+        order: -1;
+        padding: clamp(2.5rem, 8vw, 3.25rem);
     }
 
-    .auth-card {
-        padding: 2.25rem;
+    .auth-showcase {
+        padding: clamp(2.25rem, 8vw, 3.1rem);
+    }
+
+    .auth-feature-chips {
+        justify-content: flex-start;
     }
 }
 
@@ -418,24 +489,33 @@ a:hover {
         padding: 1.5rem 1rem;
     }
 
-    .auth-panel {
-        border-radius: 22px;
+    .auth-wrapper {
+        margin: clamp(1.25rem, 8vw, 2rem) auto;
+        padding: 0 1rem;
     }
 
-    .auth-hero {
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-        padding: 2rem 1.75rem;
+    .auth-panel {
+        border-radius: 24px;
+    }
+
+    .auth-showcase__cards {
+        grid-template-columns: 1fr;
     }
 
     .auth-card {
-        padding: 2rem 1.75rem 1.75rem;
+        padding: clamp(2.1rem, 9vw, 2.5rem);
+        border-radius: 22px;
     }
 
     .field-label {
         flex-direction: column;
         align-items: flex-start;
-        gap: 0.35rem;
+        gap: 0.4rem;
+    }
+
+    .auth-feature-chips li {
+        width: 100%;
+        text-align: center;
     }
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1636,440 +1636,432 @@ textarea {
     background: linear-gradient(180deg, rgba(245, 246, 251, 0), rgba(245, 246, 251, 0.95));
 }
 
-/* Dashboard refresh */
-.dashboard-shell {
-    width: min(1200px, 100% - clamp(2rem, 8vw, 8rem));
-    margin: clamp(2.8rem, 7vw, 6rem) auto clamp(3rem, 8vw, 6rem);
+/* Dashboard layout */
+.dashboard {
+    width: min(1180px, 100% - clamp(2rem, 8vw, 7rem));
+    margin: clamp(2.6rem, 7vw, 5.6rem) auto clamp(3rem, 8vw, 5.6rem);
     display: flex;
     flex-direction: column;
-    gap: clamp(2rem, 5vw, 3.5rem);
+    gap: clamp(2rem, 5vw, 3.25rem);
 }
 
-.dashboard-shell > .alert {
+.dashboard__flash {
     margin: 0;
 }
 
-.dashboard-hero {
+.dashboard-welcome {
     position: relative;
-    border-radius: 34px;
-    padding: clamp(2.6rem, 6vw, 4rem);
-    background: linear-gradient(140deg, rgba(60, 109, 240, 0.1), rgba(60, 109, 240, 0.32)), rgba(255, 255, 255, 0.95);
-    border: 1px solid rgba(60, 109, 240, 0.12);
-    box-shadow: 0 32px 80px rgba(60, 109, 240, 0.12);
+    display: grid;
+    grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+    gap: clamp(2rem, 5vw, 3rem);
+    border-radius: 32px;
+    padding: clamp(2.4rem, 5vw, 3.6rem);
+    background: linear-gradient(135deg, rgba(60, 109, 240, 0.12), rgba(60, 109, 240, 0.3)), rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(60, 109, 240, 0.14);
+    box-shadow: 0 30px 70px rgba(60, 109, 240, 0.18);
     overflow: hidden;
 }
 
-.dashboard-hero__halo {
+.dashboard-welcome::before,
+.dashboard-welcome::after {
+    content: '';
     position: absolute;
     width: 420px;
     height: 420px;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(129, 140, 248, 0.45), transparent 70%);
-    filter: blur(6px);
-    opacity: 0.85;
+    background: radial-gradient(circle, rgba(99, 102, 241, 0.4), transparent 70%);
+    filter: blur(8px);
+    opacity: 0.75;
+    pointer-events: none;
+}
+
+.dashboard-welcome::before {
+    inset: -45% auto auto -30%;
+}
+
+.dashboard-welcome::after {
     inset: auto -35% -55% auto;
+    background: radial-gradient(circle, rgba(56, 189, 248, 0.45), transparent 70%);
 }
 
-.dashboard-hero__halo--two {
-    inset: -40% auto auto -30%;
-    width: 360px;
-    height: 360px;
-    background: radial-gradient(circle, rgba(96, 165, 250, 0.4), transparent 70%);
-}
-
-.dashboard-hero__grid {
+.dashboard-welcome__content {
     position: relative;
     z-index: 1;
-    display: grid;
-    grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
-    gap: clamp(2rem, 4vw, 3.2rem);
-    align-items: stretch;
-}
-
-.dashboard-hero__primary {
     display: flex;
     flex-direction: column;
-    gap: clamp(1.4rem, 3vw, 1.9rem);
+    gap: clamp(1.2rem, 3vw, 1.8rem);
 }
 
-.dashboard-hero__eyebrow {
-    font-size: 0.75rem;
-    letter-spacing: 0.2em;
+.dashboard-welcome__eyebrow {
+    font-size: 0.78rem;
     text-transform: uppercase;
-    color: rgba(31, 41, 51, 0.65);
+    letter-spacing: 0.18em;
+    color: rgba(17, 24, 39, 0.6);
     font-weight: 600;
 }
 
-.dashboard-hero__title {
+.dashboard-welcome__title {
     margin: 0;
-    font-size: clamp(2.1rem, 5vw, 3rem);
+    font-size: clamp(2.2rem, 5vw, 3rem);
     color: #0f172a;
 }
 
-.dashboard-hero__lead {
+.dashboard-welcome__lead {
     margin: 0;
     font-size: clamp(1rem, 2.4vw, 1.12rem);
     line-height: 1.7;
-    color: rgba(15, 23, 42, 0.72);
+    color: rgba(15, 23, 42, 0.74);
     max-width: 62ch;
 }
 
-.dashboard-hero__lead strong {
-    color: var(--color-primary-dark);
-}
-
-.dashboard-hero__metrics {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: clamp(1rem, 3vw, 1.4rem);
-}
-
-.metric-card {
+.dashboard-welcome__actions {
     display: flex;
-    flex-direction: column;
-    gap: 0.55rem;
-    padding: 1.2rem 1.3rem;
-    border-radius: 20px;
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid rgba(60, 109, 240, 0.12);
-    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
-    backdrop-filter: blur(6px);
-}
-
-.metric-card--accent {
-    background: linear-gradient(150deg, rgba(96, 165, 250, 0.22), rgba(60, 109, 240, 0.3));
-    border-color: rgba(60, 109, 240, 0.22);
-}
-
-.metric-card__top {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
+    flex-wrap: wrap;
     gap: 0.75rem;
 }
 
-.metric-card__label {
+.dashboard-welcome__meta {
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.dashboard-welcome__meta div {
+    padding: 1rem 1.2rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.7);
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
+}
+
+.dashboard-welcome__meta dt {
     font-size: 0.78rem;
     text-transform: uppercase;
     letter-spacing: 0.14em;
     color: rgba(15, 23, 42, 0.55);
-    font-weight: 600;
 }
 
-.metric-card__value {
-    font-size: 1.7rem;
+.dashboard-welcome__meta dd {
+    margin: 0.35rem 0 0;
+    font-size: 1.6rem;
     font-weight: 700;
     color: #0f172a;
 }
 
-.metric-card__progress {
-    width: 100%;
-    height: 6px;
-    border-radius: 999px;
-    background: rgba(60, 109, 240, 0.14);
-    overflow: hidden;
-}
-
-.metric-card__progress span {
+.dashboard-welcome__meta small {
     display: block;
-    height: 100%;
-    border-radius: inherit;
-    background: linear-gradient(120deg, rgba(129, 140, 248, 0.8), rgba(59, 130, 246, 0.9));
+    margin-top: 0.4rem;
+    font-size: 0.82rem;
+    color: rgba(15, 23, 42, 0.55);
 }
 
-.metric-card__meta {
+.dashboard-welcome__panel {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 1.4rem;
+}
+
+.welcome-card {
+    display: grid;
+    gap: 0.9rem;
+    padding: 1.6rem;
+    border-radius: 24px;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+}
+
+.welcome-card--ai {
+    background: linear-gradient(160deg, rgba(60, 109, 240, 0.18), rgba(59, 130, 246, 0.28));
+    color: #0f172a;
+}
+
+.welcome-card--support {
+    background: rgba(240, 249, 255, 0.88);
+}
+
+.welcome-card__eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: rgba(15, 23, 42, 0.65);
+    font-weight: 600;
+}
+
+.welcome-card__title {
+    margin: 0;
+    font-size: 1.6rem;
+    color: #0f172a;
+}
+
+.welcome-card__lead {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(15, 23, 42, 0.72);
+}
+
+.welcome-card__hint {
+    margin: 0;
+    font-size: 0.82rem;
+    color: rgba(15, 23, 42, 0.62);
+}
+
+.data-list {
+    display: grid;
+    gap: 0.65rem;
+    margin: 0;
+}
+
+.data-list div {
+    display: grid;
+    gap: 0.25rem;
+}
+
+.data-list dt {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.data-list dd {
+    margin: 0;
+    font-weight: 600;
+    color: #0f172a;
+    word-break: break-word;
+}
+
+.dashboard-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.2rem;
+}
+
+.stat-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.4rem 1.5rem;
+    border-radius: 22px;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+.stat-card__icon {
+    font-size: 1.85rem;
+    line-height: 1;
+}
+
+.stat-card__label {
+    margin: 0;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: rgba(15, 23, 42, 0.55);
+}
+
+.stat-card__value {
+    margin: 0.35rem 0 0;
+    font-size: 1.85rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.stat-card__meta {
+    margin: 0.2rem 0 0;
     font-size: 0.88rem;
     color: rgba(15, 23, 42, 0.6);
 }
 
-.dashboard-hero__actions {
+.dashboard-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
+    gap: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.panel,
+.panel-group > .panel {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.85rem;
-    align-items: center;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: clamp(1.6rem, 4vw, 2rem);
+    border-radius: 26px;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 22px 46px rgba(15, 23, 42, 0.09);
 }
 
-.dashboard-hero__secondary {
-    display: grid;
-    gap: 1.2rem;
-    align-content: flex-start;
+.panel--accent {
+    background: linear-gradient(165deg, rgba(59, 130, 246, 0.12), rgba(191, 219, 254, 0.35));
 }
 
-.dashboard-card {
-    display: grid;
-    gap: 1rem;
-    padding: 1.6rem 1.7rem;
-    border-radius: 22px;
-    background: rgba(255, 255, 255, 0.95);
-    border: 1px solid rgba(60, 109, 240, 0.12);
-    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.1);
+.panel--secondary {
+    background: rgba(247, 249, 255, 0.9);
 }
 
-.dashboard-card--ai {
-    background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(226, 232, 255, 0.72));
-}
-
-.dashboard-card__eyebrow {
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: rgba(15, 23, 42, 0.55);
-    font-weight: 600;
-}
-
-.dashboard-card__title {
+.panel__header h2 {
     margin: 0;
     font-size: 1.35rem;
     color: #0f172a;
 }
 
-.dashboard-card__list {
-    display: grid;
-    gap: 0.75rem;
-    margin: 0;
-}
-
-.dashboard-card__list div {
-    display: grid;
-    gap: 0.25rem;
-}
-
-.dashboard-card__list dt {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: rgba(15, 23, 42, 0.5);
-}
-
-.dashboard-card__list dd {
-    margin: 0;
-    font-weight: 600;
-    color: #111827;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.dashboard-card__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-}
-
-.dashboard-card__hint {
-    margin: 0;
-    font-size: 0.85rem;
-    color: rgba(15, 23, 42, 0.62);
-}
-
-.spotlight-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 0.85rem;
-}
-
-.spotlight-list li {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
+.panel__header p {
+    margin: 0.45rem 0 0;
     font-size: 0.95rem;
-    color: rgba(15, 23, 42, 0.6);
-}
-
-.spotlight-list strong {
-    color: #0f172a;
-}
-
-.dashboard-overview {
-    display: flex;
-    flex-direction: column;
-    gap: 1.6rem;
-}
-
-.dashboard-section__header {
-    display: grid;
-    gap: 0.6rem;
-    max-width: 640px;
-}
-
-.dashboard-section__header h2 {
-    margin: 0;
-    font-size: 1.65rem;
-    color: #0f172a;
-}
-
-.dashboard-section__header p {
-    margin: 0;
-    font-size: 0.98rem;
-    color: rgba(15, 23, 42, 0.65);
-}
-
-.overview-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: clamp(1rem, 3vw, 1.5rem);
-}
-
-.overview-card {
-    border-radius: 20px;
-    padding: 1.6rem 1.8rem;
-    background: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(235, 240, 255, 0.92));
-    border: 1px solid rgba(60, 109, 240, 0.12);
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
-    display: grid;
-    gap: 0.7rem;
-}
-
-.overview-card__icon {
-    font-size: 1.6rem;
-}
-
-.overview-card h3 {
-    margin: 0;
-    font-size: 1.15rem;
-    color: #0f172a;
-}
-
-.overview-card p {
-    margin: 0;
     color: rgba(15, 23, 42, 0.62);
-    line-height: 1.6;
 }
 
-.dashboard-main {
-    display: grid;
-    grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
-    gap: clamp(1.6rem, 4vw, 2.6rem);
-    align-items: start;
-}
-
-.module-card {
-    background: rgba(255, 255, 255, 0.96);
-    border-radius: 26px;
-    padding: clamp(1.8rem, 3vw, 2.4rem);
-    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.12);
-    border: 1px solid rgba(60, 109, 240, 0.12);
+.panel-group {
     display: grid;
     gap: 1.5rem;
 }
 
-.module-card__header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 1rem;
-}
-
-.module-card__header h2 {
-    margin: 0;
-    font-size: 1.45rem;
-    color: #0f172a;
-}
-
-.module-card__description {
-    margin: 0.4rem 0 0;
-    font-size: 0.95rem;
-    color: rgba(15, 23, 42, 0.65);
-}
-
-.empty-state {
-    text-align: center;
-    display: grid;
-    gap: 0.85rem;
-    padding: 2.4rem 1.6rem;
-    border-radius: 22px;
-    background: rgba(243, 246, 255, 0.6);
-    border: 1px dashed rgba(60, 109, 240, 0.25);
-}
-
-.empty-state h3 {
-    margin: 0;
-    font-size: 1.2rem;
-}
-
-.empty-state p {
-    margin: 0;
-    color: rgba(15, 23, 42, 0.62);
-}
-
 .survey-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     display: grid;
-    gap: 1rem;
+    gap: 1.2rem;
 }
 
-.survey-item {
+.survey-card {
     display: grid;
     gap: 1rem;
-    padding: 1.4rem 1.5rem;
-    border-radius: 20px;
-    border: 1px solid rgba(226, 232, 240, 0.8);
-    background: rgba(255, 255, 255, 0.9);
-    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.07);
+    padding: 1.3rem 1.5rem;
+    border-radius: 22px;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: 0 16px 38px rgba(15, 23, 42, 0.07);
 }
 
-.survey-item__header {
+.survey-card__header {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
     gap: 1rem;
 }
 
-.survey-item__header h3 {
+.survey-card__header h3 {
     margin: 0;
     font-size: 1.18rem;
     color: #0f172a;
 }
 
-.survey-item__meta {
-    display: inline-block;
-    margin-top: 0.35rem;
-    font-size: 0.83rem;
-    color: rgba(15, 23, 42, 0.55);
+.survey-card__meta {
+    margin: 0;
+    font-size: 0.88rem;
+    color: rgba(15, 23, 42, 0.6);
 }
 
-.survey-item__dates {
+.survey-card__dates {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.9rem;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
     margin: 0;
 }
 
-.survey-item__dates div {
+.survey-card__dates div {
     display: grid;
-    gap: 0.25rem;
+    gap: 0.3rem;
 }
 
-.survey-item__dates dt {
-    font-size: 0.75rem;
+.survey-card__dates dt {
+    font-size: 0.78rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
-    color: rgba(15, 23, 42, 0.5);
+    color: rgba(15, 23, 42, 0.55);
 }
 
-.survey-item__dates dd {
+.survey-card__dates dd {
     margin: 0;
     font-weight: 600;
     color: #0f172a;
 }
 
-.survey-item__actions {
+.survey-card__actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
 }
 
-.dashboard-sidebar {
+.focus-card {
     display: grid;
-    gap: 1.5rem;
+    gap: 1rem;
+    padding: 1.3rem 1.5rem;
+    border-radius: 22px;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    background: rgba(255, 255, 255, 0.92);
 }
 
-.action-list {
+.focus-card h3 {
+    margin: 0;
+    font-size: 1.15rem;
+    color: #0f172a;
+}
+
+.focus-card dl {
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.focus-card dl div {
+    display: grid;
+    gap: 0.25rem;
+}
+
+.focus-card dt {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(15, 23, 42, 0.55);
+}
+
+.focus-card dd {
+    margin: 0;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.focus-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.empty-state {
+    text-align: center;
+    display: grid;
+    gap: 0.9rem;
+    padding: 2.2rem 1.8rem;
+    border-radius: 24px;
+    background: rgba(243, 246, 255, 0.8);
+    border: 1px dashed rgba(60, 109, 240, 0.35);
+}
+
+.empty-state h3 {
+    margin: 0;
+    font-size: 1.22rem;
+    color: #0f172a;
+}
+
+.empty-state p {
+    margin: 0;
+    color: rgba(15, 23, 42, 0.66);
+}
+
+.empty-hint {
+    padding: 1.2rem 1.3rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.8);
+    border: 1px dashed rgba(59, 130, 246, 0.35);
+    color: rgba(15, 23, 42, 0.65);
+}
+
+.quick-actions {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -2077,141 +2069,140 @@ textarea {
     gap: 1rem;
 }
 
-.action-list__item {
+.quick-actions__item {
     display: grid;
     grid-template-columns: auto 1fr;
-    gap: 0.9rem;
+    gap: 1rem;
     align-items: flex-start;
-    padding: 1.1rem 1.2rem;
-    border-radius: 18px;
-    border: 1px solid rgba(226, 232, 240, 0.8);
+    padding: 1.1rem 1.3rem;
+    border-radius: 20px;
+    border: 1px solid rgba(226, 232, 240, 0.85);
     background: rgba(247, 249, 255, 0.95);
-    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
+    box-shadow: 0 16px 34px rgba(15, 23, 42, 0.08);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.action-list__item:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 22px 42px rgba(15, 23, 42, 0.12);
+.quick-actions__item:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 22px 40px rgba(15, 23, 42, 0.12);
 }
 
-.action-list__item.is-disabled {
-    opacity: 0.65;
+.quick-actions__item.is-disabled {
+    opacity: 0.6;
     pointer-events: none;
 }
 
-.action-list__icon {
-    font-size: 1.5rem;
+.quick-actions__icon {
+    font-size: 1.6rem;
     line-height: 1;
 }
 
-.action-list__body strong {
+.quick-actions__body {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.quick-actions__body strong {
     font-size: 1.02rem;
-    color: #111827;
-}
-
-.action-list__body p {
-    margin: 0.35rem 0 0;
-    font-size: 0.92rem;
-    color: rgba(17, 24, 39, 0.6);
-}
-
-.action-list__hint {
-    display: inline-block;
-    margin-top: 0.5rem;
-    font-size: 0.82rem;
-    color: rgba(17, 24, 39, 0.55);
-}
-
-.support-card {
-    background: linear-gradient(150deg, rgba(224, 231, 255, 0.55), rgba(199, 210, 254, 0.7));
-    gap: 0.8rem;
-}
-
-.support-card h2 {
-    margin: 0;
-    font-size: 1.25rem;
     color: #0f172a;
 }
 
-.support-card p {
+.quick-actions__body p {
     margin: 0;
-    color: rgba(15, 23, 42, 0.65);
-    line-height: 1.6;
+    font-size: 0.92rem;
+    color: rgba(15, 23, 42, 0.6);
 }
 
-.support-card .button-secondary {
-    justify-content: center;
-    align-self: flex-start;
-}
-
-.support-card__meta {
-    font-size: 0.9rem;
+.quick-actions__hint {
+    font-size: 0.82rem;
     color: rgba(15, 23, 42, 0.55);
+}
+
+.insight-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.9rem;
+}
+
+.insight-list li {
+    position: relative;
+    padding-left: 1.4rem;
+    font-size: 0.95rem;
+    color: rgba(15, 23, 42, 0.68);
+}
+
+.insight-list li::before {
+    content: '';
+    position: absolute;
+    inset: 0 auto 0 0.2rem;
+    width: 6px;
+    height: 6px;
+    margin: auto 0;
+    border-radius: 50%;
+    background: var(--color-primary);
 }
 
 .status-pill {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
-    padding: 0.35rem 0.75rem;
+    gap: 0.35rem;
+    padding: 0.3rem 0.75rem;
     border-radius: 999px;
-    font-size: 0.85rem;
+    font-size: 0.82rem;
     font-weight: 600;
     background: rgba(60, 109, 240, 0.12);
     color: var(--color-primary);
     text-transform: capitalize;
 }
 
-@media (max-width: 1180px) {
-    .dashboard-shell {
-        width: calc(100% - clamp(1.5rem, 5vw, 3.2rem));
+@media (max-width: 1100px) {
+    .dashboard {
+        width: calc(100% - clamp(1.8rem, 6vw, 4rem));
     }
-}
 
-@media (max-width: 1080px) {
-    .dashboard-hero__grid {
+    .dashboard-welcome {
         grid-template-columns: 1fr;
     }
 
-    .dashboard-hero__secondary {
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    .dashboard-welcome__panel {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
 
-    .dashboard-main {
+    .dashboard-layout {
         grid-template-columns: 1fr;
     }
 }
 
-@media (max-width: 780px) {
-    .dashboard-shell {
-        width: calc(100% - 2.4rem);
-        margin: 1.8rem auto 3.5rem;
+@media (max-width: 720px) {
+    .dashboard {
+        width: calc(100% - 1.6rem);
+        margin: 2.2rem auto 3.5rem;
     }
 
-    .dashboard-hero {
-        border-radius: 28px;
-        padding: 2.4rem 2rem;
+    .dashboard-welcome {
+        padding: 2.2rem 1.6rem;
     }
 
-    .dashboard-hero__actions,
-    .survey-item__actions {
+    .dashboard-welcome__actions,
+    .survey-card__actions,
+    .focus-card__actions {
         flex-direction: column;
         align-items: stretch;
     }
 
-    .dashboard-card,
-    .module-card {
-        border-radius: 22px;
+    .quick-actions__item {
+        grid-template-columns: 1fr;
     }
 }
 
-@media (max-width: 560px) {
-    .dashboard-hero__metrics {
+@media (max-width: 520px) {
+    .dashboard-welcome__meta {
         grid-template-columns: 1fr;
     }
 
-    .action-list__item {
+    .dashboard-stats {
         grid-template-columns: 1fr;
     }
 }

--- a/config.sample.php
+++ b/config.sample.php
@@ -20,6 +20,14 @@ return [
     'security' => [
         'token_salt' => 'please-change-this-secret',
     ],
+    'ai' => [
+        'provider' => 'openai',
+        'api_key' => '',
+        'model' => 'gpt-4o-mini',
+        'base_url' => 'https://api.openai.com/v1',
+        'deployment' => '',
+        'azure_api_version' => '2024-02-15-preview',
+    ],
     'openai' => [
         'api_key' => '',
         'model' => 'gpt-4o-mini',

--- a/dashboard.php
+++ b/dashboard.php
@@ -61,37 +61,46 @@ include __DIR__ . '/templates/navbar.php';
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
     <?php endif; ?>
 
-    <section class="dashboard-hero">
-        <div class="dashboard-hero__grid">
-            <div class="dashboard-hero__content">
-                <span class="dashboard-hero__badge">Kontrol Merkezi</span>
+    <section class="welcome-hero">
+        <span class="welcome-hero__glow" aria-hidden="true"></span>
+        <span class="welcome-hero__orb welcome-hero__orb--one" aria-hidden="true"></span>
+        <span class="welcome-hero__orb welcome-hero__orb--two" aria-hidden="true"></span>
+
+        <div class="welcome-hero__inner">
+            <div class="welcome-hero__copy">
+                <span class="welcome-hero__badge">Kontrol Merkezi</span>
                 <h1>Hoş geldin <?php echo h(current_user_name()); ?> 👋</h1>
-                <p class="dashboard-hero__lead">
-                    <?php echo (int)$stats['active']; ?> aktif anket ve <?php echo (int)$stats['pending']; ?> bekleyen davetle <strong><?php echo h(config('app.name', 'Anketor')); ?></strong> topluluk nabzını tutuyor. Hızlı aksiyonlar için öne çıkan kartları değerlendirebilirsin.
+                <p class="welcome-hero__lead">
+                    <?php echo (int)$stats['active']; ?> aktif anket, <?php echo (int)$stats['responses']; ?> yanıt ve <?php echo (int)$stats['pending']; ?> bekleyen davet ile <strong><?php echo h(config('app.name', 'Anketor')); ?></strong> topluluğunun nabzını tutuyoruz.
                 </p>
 
-                <div class="dashboard-hero__highlights">
-                    <article class="highlight-card">
-                        <span class="highlight-card__label">Yanıt oranı</span>
-                        <span class="highlight-card__value"><?php echo $totalInvites > 0 ? h($responseRate) . '%' : 'N/A'; ?></span>
-                        <span class="highlight-card__meta"><?php echo $totalInvites > 0 ? h($totalInvites) . ' toplam davet' : 'Henüz davet gönderilmedi'; ?></span>
-                        <span class="highlight-card__progress" aria-hidden="true">
+                <div class="welcome-hero__stats">
+                    <article class="stat-bubble stat-bubble--accent">
+                        <span class="stat-bubble__label">Yanıt oranı</span>
+                        <span class="stat-bubble__value"><?php echo $totalInvites > 0 ? h($responseRate) . '%' : 'N/A'; ?></span>
+                        <span class="stat-bubble__meta"><?php echo $totalInvites > 0 ? h($totalInvites) . ' toplam davet' : 'Henüz davet yok'; ?></span>
+                        <span class="stat-bubble__progress" aria-hidden="true">
                             <span style="width: <?php echo max(8, min(100, $responseRate)); ?>%"></span>
                         </span>
                     </article>
-                    <article class="highlight-card">
-                        <span class="highlight-card__label">Aktif anket</span>
-                        <span class="highlight-card__value"><?php echo (int)$stats['active']; ?></span>
-                        <span class="highlight-card__meta"><?php echo (int)$stats['surveys']; ?> toplam anket içinde yayında.</span>
+                    <article class="stat-bubble">
+                        <span class="stat-bubble__label">Aktif anket</span>
+                        <span class="stat-bubble__value"><?php echo (int)$stats['active']; ?></span>
+                        <span class="stat-bubble__meta"><?php echo (int)$stats['surveys']; ?> toplam anket içerisinde.</span>
                     </article>
-                    <article class="highlight-card">
-                        <span class="highlight-card__label">Bekleyen davet</span>
-                        <span class="highlight-card__value"><?php echo (int)$stats['pending']; ?></span>
-                        <span class="highlight-card__meta"><?php echo (int)$stats['responses']; ?> yanıt tamamlandı.</span>
+                    <article class="stat-bubble">
+                        <span class="stat-bubble__label">Toplanan yanıt</span>
+                        <span class="stat-bubble__value"><?php echo (int)$stats['responses']; ?></span>
+                        <span class="stat-bubble__meta">Son dönem raporlarında kullanıldı.</span>
+                    </article>
+                    <article class="stat-bubble">
+                        <span class="stat-bubble__label">Bekleyen davet</span>
+                        <span class="stat-bubble__value"><?php echo (int)$stats['pending']; ?></span>
+                        <span class="stat-bubble__meta">Takip edilmeyi bekliyor.</span>
                     </article>
                 </div>
 
-                <div class="dashboard-hero__actions">
+                <div class="welcome-hero__actions">
                     <a class="button-primary" href="survey_edit.php">Yeni Anket Oluştur</a>
                     <?php if (!empty($primarySurvey['id'])): ?>
                         <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$primarySurvey['id']; ?>">Soruları düzenle</a>
@@ -100,10 +109,10 @@ include __DIR__ . '/templates/navbar.php';
                 </div>
             </div>
 
-            <div class="dashboard-hero__panel">
-                <div class="glass-card">
-                    <span class="glass-card__badge">Yapay zekâ</span>
-                    <h3>Yapılandırma Özeti</h3>
+            <aside class="welcome-hero__panels">
+                <div class="welcome-panel welcome-panel--ai">
+                    <span class="welcome-panel__badge">Yapay zekâ</span>
+                    <h2>Yapılandırma Özeti</h2>
                     <dl class="ai-config__list">
                         <div>
                             <dt>Sağlayıcı</dt>
@@ -129,142 +138,117 @@ include __DIR__ . '/templates/navbar.php';
                         <?php endif; ?>
                     </dl>
                     <?php if (current_user_role() === 'super_admin'): ?>
-                        <a class="button-secondary ai-config__action" href="system_settings.php">Genel ayarları yönet</a>
+                        <a class="button-secondary welcome-panel__cta" href="system_settings.php">Genel ayarları yönet</a>
                     <?php else: ?>
-                        <p class="ai-config__hint">Genel ayarlar süper yönetici tarafından yönetilir.</p>
+                        <p class="welcome-panel__hint">Genel ayarlar süper yönetici tarafından yönetilir.</p>
                     <?php endif; ?>
                 </div>
 
-                <?php if ($primarySurvey): ?>
-                    <div class="spotlight-card">
-                        <span class="spotlight-card__label">Odak Anket</span>
-                        <h3><?php echo h($primarySurvey['title']); ?></h3>
-                        <ul class="spotlight-card__meta">
-                            <li><strong>Durum:</strong> <span class="status-pill status-<?php echo h($primarySurvey['status']); ?>"><?php echo h($primarySurvey['status']); ?></span></li>
-                            <li><strong>Dönem:</strong> <?php echo $primarySurvey['start_date'] ? h(format_date($primarySurvey['start_date'])) : '-'; ?> — <?php echo $primarySurvey['end_date'] ? h(format_date($primarySurvey['end_date'])) : '-'; ?></li>
+                <div class="welcome-panel welcome-panel--spotlight">
+                    <?php if ($primarySurvey): ?>
+                        <span class="welcome-panel__badge">Odak anket</span>
+                        <h2><?php echo h($primarySurvey['title']); ?></h2>
+                        <ul class="spotlight-meta">
+                            <li>
+                                <span>Durum</span>
+                                <strong class="status-pill status-<?php echo h($primarySurvey['status']); ?>"><?php echo h($primarySurvey['status']); ?></strong>
+                            </li>
+                            <li>
+                                <span>Dönem</span>
+                                <strong><?php echo $primarySurvey['start_date'] ? h(format_date($primarySurvey['start_date'])) : '-'; ?> — <?php echo $primarySurvey['end_date'] ? h(format_date($primarySurvey['end_date'])) : '-'; ?></strong>
+                            </li>
                         </ul>
-                        <div class="spotlight-card__actions">
+                        <div class="welcome-panel__actions">
                             <a class="button-secondary" href="participants.php?id=<?php echo (int)$primarySurvey['id']; ?>">Katılımcıları yönet</a>
                             <a class="button-link" href="survey_edit.php?id=<?php echo (int)$primarySurvey['id']; ?>">Detayları düzenle</a>
                         </div>
+                    <?php else: ?>
+                        <span class="welcome-panel__badge">Başlangıç</span>
+                        <h2>İlk anketini başlat</h2>
+                        <p>Katılımcı deneyimini izlemek için yeni bir anket oluştur, davetleri planla ve raporları takip et.</p>
+                        <div class="welcome-panel__actions">
+                            <a class="button-secondary" href="survey_edit.php">Anket oluştur</a>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </aside>
+        </div>
+    </section>
+
+    <section class="dashboard-panels">
+        <div class="panels-grid">
+            <div class="panel panel--surveys">
+                <header class="panel__header">
+                    <div>
+                        <h2>Son anketler</h2>
+                        <p class="panel__description">Ekibinin güncel çalışmalarını takip ederek hızlıca aksiyon al.</p>
+                    </div>
+                    <a class="button-link" href="surveys.php">Tümünü gör</a>
+                </header>
+
+                <?php if (empty($recentSurveys)): ?>
+                    <div class="empty-block">
+                        <h3>Henüz anket oluşturulmadı</h3>
+                        <p>İlk anketini oluşturduğunda burada özetini göreceksin.</p>
+                        <a class="button-primary" href="survey_edit.php">Anket oluştur</a>
                     </div>
                 <?php else: ?>
-                    <div class="spotlight-card">
-                        <span class="spotlight-card__label">Odak alanı</span>
-                        <h3>Henüz odaklanılmış bir anket yok</h3>
-                        <p>Yeni bir anket oluşturarak raporlar ve hızlı aksiyonlar için temel veriyi oluşturabilirsin.</p>
-                        <div class="spotlight-card__actions">
-                            <a class="button-secondary" href="survey_edit.php">İlk anketini başlat</a>
-                        </div>
+                    <div class="survey-cards">
+                        <?php foreach ($recentSurveys as $survey): ?>
+                            <article class="survey-card">
+                                <div class="survey-card__top">
+                                    <div>
+                                        <h3 class="survey-card__title"><?php echo h($survey['title']); ?></h3>
+                                        <span class="survey-card__category"><?php echo h($survey['category_name'] ?? 'Genel'); ?></span>
+                                    </div>
+                                    <span class="status-pill status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
+                                </div>
+                                <dl class="survey-card__meta">
+                                    <div>
+                                        <dt>Başlangıç</dt>
+                                        <dd><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></dd>
+                                    </div>
+                                    <div>
+                                        <dt>Bitiş</dt>
+                                        <dd><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></dd>
+                                    </div>
+                                </dl>
+                                <div class="survey-card__actions">
+                                    <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Soruları yönet</a>
+                                    <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Detayları düzenle</a>
+                                </div>
+                            </article>
+                        <?php endforeach; ?>
                     </div>
                 <?php endif; ?>
             </div>
-        </div>
-    </section>
 
-    <section class="dashboard-overview">
-        <div class="overview-grid">
-            <article class="overview-card">
-                <span class="overview-card__icon">📋</span>
-                <span class="overview-card__label">Toplam anket</span>
-                <p class="overview-card__value"><?php echo (int)$stats['surveys']; ?></p>
-                <p class="overview-card__hint">Tüm ekipler tarafından bugüne kadar oluşturulan projeler.</p>
-            </article>
-            <article class="overview-card overview-card--success">
-                <span class="overview-card__icon">🚀</span>
-                <span class="overview-card__label">Aktif anket</span>
-                <p class="overview-card__value"><?php echo (int)$stats['active']; ?></p>
-                <p class="overview-card__hint">Katılımcıların şu anda erişebildiği çalışmaları temsil eder.</p>
-            </article>
-            <article class="overview-card overview-card--success">
-                <span class="overview-card__icon">✅</span>
-                <span class="overview-card__label">Toplanan cevap</span>
-                <p class="overview-card__value"><?php echo (int)$stats['responses']; ?></p>
-                <p class="overview-card__hint">İçgörüleri güçlendiren tamamlanmış geri bildirimler.</p>
-            </article>
-            <article class="overview-card overview-card--warning">
-                <span class="overview-card__icon">⏳</span>
-                <span class="overview-card__label">Bekleyen davet</span>
-                <p class="overview-card__value"><?php echo (int)$stats['pending']; ?></p>
-                <p class="overview-card__hint">Takip edilmesi gereken ve dönüş bekleyen davetliler.</p>
-            </article>
-        </div>
-    </section>
-
-    <section class="dashboard-layout">
-        <div class="surface-card">
-            <div class="surface-card__header">
-                <div>
-                    <h2>Son anketler</h2>
-                    <p class="surface-card__description">Ekibinin en güncel çalışmalarını buradan takip et.</p>
-                </div>
-                <a class="button-link" href="surveys.php">Tümünü gör</a>
-            </div>
-
-            <?php if (empty($recentSurveys)): ?>
-                <div class="empty-state">
-                    <h3>Henüz anket oluşturulmadı</h3>
-                    <p>İlk anketini oluşturduğunda burada özetini göreceksin.</p>
-                    <a class="button-primary" href="survey_edit.php">Anket oluştur</a>
-                </div>
-            <?php else: ?>
-                <div class="survey-list">
-                    <?php foreach ($recentSurveys as $survey): ?>
-                        <article class="survey-item">
-                            <div class="survey-item__header">
-                                <div>
-                                    <h3 class="survey-item__title"><?php echo h($survey['title']); ?></h3>
-                                    <span class="survey-item__category"><?php echo h($survey['category_name'] ?? 'Genel'); ?></span>
-                                </div>
-                                <span class="status-pill status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
-                            </div>
-                            <ul class="survey-item__meta">
-                                <li>
-                                    <span>Başlangıç</span>
-                                    <strong><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></strong>
-                                </li>
-                                <li>
-                                    <span>Bitiş</span>
-                                    <strong><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></strong>
-                                </li>
-                            </ul>
-                            <div class="survey-item__actions">
-                                <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Soruları yönet</a>
-                                <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Detayları düzenle</a>
-                            </div>
-                        </article>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-        </div>
-
-        <aside class="dashboard-layout__aside">
-            <div class="surface-card">
-                <div class="surface-card__header">
+            <aside class="panel panel--sidebar">
+                <div class="quick-actions">
                     <h2>Hızlı işlemler</h2>
+                    <ul>
+                        <?php foreach ($quickActions as $action): ?>
+                            <li>
+                                <span class="quick-actions__icon"><?php echo h($action['icon']); ?></span>
+                                <div>
+                                    <strong><?php echo h($action['title']); ?></strong>
+                                    <p><?php echo h($action['description']); ?></p>
+                                    <?php if (!empty($action['url']) && !empty($action['label'])): ?>
+                                        <a class="button-link" href="<?php echo h($action['url']); ?>"><?php echo h($action['label']); ?></a>
+                                    <?php endif; ?>
+                                </div>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
                 </div>
-                <ul class="quick-actions-list">
-                    <?php foreach ($quickActions as $action): ?>
-                        <li class="quick-actions-list__item">
-                            <span class="quick-actions-list__icon"><?php echo h($action['icon']); ?></span>
-                            <div class="quick-actions-list__content">
-                                <strong><?php echo h($action['title']); ?></strong>
-                                <p><?php echo h($action['description']); ?></p>
-                                <?php if (!empty($action['url']) && !empty($action['label'])): ?>
-                                    <a class="button-link" href="<?php echo h($action['url']); ?>"><?php echo h($action['label']); ?></a>
-                                <?php endif; ?>
-                            </div>
-                        </li>
-                    <?php endforeach; ?>
-                </ul>
-            </div>
 
-            <div class="support-card">
-                <strong>Desteğe mi ihtiyacın var?</strong>
-                <p>Süreçleri yapılandırırken takıldığında ekibimize <a href="mailto:support@anketor.com">support@anketor.com</a> adresinden ulaşabilirsin.</p>
-                <p>Ayrıca yardım merkezindeki hızlı başlangıç rehberleriyle yeni özellikleri keşfet.</p>
-            </div>
-        </aside>
+                <div class="support-callout">
+                    <strong>Desteğe mi ihtiyacın var?</strong>
+                    <p>Sürece dair sorularında ekibimize <a href="mailto:support@anketor.com">support@anketor.com</a> adresinden ulaşabilirsin.</p>
+                    <p>Yardım merkezindeki rehberlerle yeni özellikleri de keşfedebilirsin.</p>
+                </div>
+            </aside>
+        </div>
     </section>
 </main>
 <?php include __DIR__ . '/templates/footer.php'; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -33,6 +33,7 @@ $quickActions = [
         'description' => 'Sistem ayarlarından sağlayıcıyı güncelleyerek raporlardaki içgörüleri uyarlayın.',
         'url' => current_user_role() === 'super_admin' ? 'system_settings.php' : null,
         'label' => 'Ayarları aç',
+        'hint' => current_user_role() === 'super_admin' ? null : 'Bu ayarı sadece süper admin güncelleyebilir.',
     ],
     [
         'icon' => '🗂️',
@@ -40,6 +41,7 @@ $quickActions = [
         'description' => 'Sık kullanılan soruları düzenleyip taslaklarınıza ekleyin.',
         'url' => 'survey_questions.php',
         'label' => 'Soru havuzu',
+        'hint' => null,
     ],
     [
         'icon' => '📨',
@@ -47,6 +49,7 @@ $quickActions = [
         'description' => 'Katılım oranını artırmak için yanıt vermeyenlere toplu e-posta gönderin.',
         'url' => $primarySurvey ? 'participants.php?id=' . (int)$primarySurvey['id'] : null,
         'label' => $primarySurvey ? 'Katılımcıları yönet' : null,
+        'hint' => $primarySurvey ? null : 'Odaklanacak bir anket seçildiğinde etkinleşir.',
     ],
 ];
 
@@ -61,46 +64,47 @@ include __DIR__ . '/templates/navbar.php';
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
     <?php endif; ?>
 
-    <section class="welcome-hero">
-        <span class="welcome-hero__glow" aria-hidden="true"></span>
-        <span class="welcome-hero__orb welcome-hero__orb--one" aria-hidden="true"></span>
-        <span class="welcome-hero__orb welcome-hero__orb--two" aria-hidden="true"></span>
+    <section class="dashboard-hero">
+        <span class="dashboard-hero__halo" aria-hidden="true"></span>
+        <span class="dashboard-hero__halo dashboard-hero__halo--two" aria-hidden="true"></span>
 
-        <div class="welcome-hero__inner">
-            <div class="welcome-hero__copy">
-                <span class="welcome-hero__badge">Kontrol Merkezi</span>
-                <h1>Hoş geldin <?php echo h(current_user_name()); ?> 👋</h1>
-                <p class="welcome-hero__lead">
+        <div class="dashboard-hero__grid">
+            <div class="dashboard-hero__primary">
+                <span class="dashboard-hero__eyebrow">Kontrol Merkezi</span>
+                <h1 class="dashboard-hero__title">Merhaba <?php echo h(current_user_name()); ?> 👋</h1>
+                <p class="dashboard-hero__lead">
                     <?php echo (int)$stats['active']; ?> aktif anket, <?php echo (int)$stats['responses']; ?> yanıt ve <?php echo (int)$stats['pending']; ?> bekleyen davet ile <strong><?php echo h(config('app.name', 'Anketor')); ?></strong> topluluğunun nabzını tutuyoruz.
                 </p>
 
-                <div class="welcome-hero__stats">
-                    <article class="stat-bubble stat-bubble--accent">
-                        <span class="stat-bubble__label">Yanıt oranı</span>
-                        <span class="stat-bubble__value"><?php echo $totalInvites > 0 ? h($responseRate) . '%' : 'N/A'; ?></span>
-                        <span class="stat-bubble__meta"><?php echo $totalInvites > 0 ? h($totalInvites) . ' toplam davet' : 'Henüz davet yok'; ?></span>
-                        <span class="stat-bubble__progress" aria-hidden="true">
+                <ul class="dashboard-hero__metrics">
+                    <li class="metric-card metric-card--accent">
+                        <div class="metric-card__top">
+                            <span class="metric-card__label">Yanıt oranı</span>
+                            <span class="metric-card__value"><?php echo $totalInvites > 0 ? h($responseRate) . '%' : 'N/A'; ?></span>
+                        </div>
+                        <div class="metric-card__progress" aria-hidden="true">
                             <span style="width: <?php echo max(8, min(100, $responseRate)); ?>%"></span>
-                        </span>
-                    </article>
-                    <article class="stat-bubble">
-                        <span class="stat-bubble__label">Aktif anket</span>
-                        <span class="stat-bubble__value"><?php echo (int)$stats['active']; ?></span>
-                        <span class="stat-bubble__meta"><?php echo (int)$stats['surveys']; ?> toplam anket içerisinde.</span>
-                    </article>
-                    <article class="stat-bubble">
-                        <span class="stat-bubble__label">Toplanan yanıt</span>
-                        <span class="stat-bubble__value"><?php echo (int)$stats['responses']; ?></span>
-                        <span class="stat-bubble__meta">Son dönem raporlarında kullanıldı.</span>
-                    </article>
-                    <article class="stat-bubble">
-                        <span class="stat-bubble__label">Bekleyen davet</span>
-                        <span class="stat-bubble__value"><?php echo (int)$stats['pending']; ?></span>
-                        <span class="stat-bubble__meta">Takip edilmeyi bekliyor.</span>
-                    </article>
-                </div>
+                        </div>
+                        <span class="metric-card__meta"><?php echo $totalInvites > 0 ? h($totalInvites) . ' toplam davet' : 'Henüz davet yok'; ?></span>
+                    </li>
+                    <li class="metric-card">
+                        <span class="metric-card__label">Aktif anket</span>
+                        <span class="metric-card__value"><?php echo (int)$stats['active']; ?></span>
+                        <span class="metric-card__meta"><?php echo (int)$stats['surveys']; ?> toplam anket içerisinde</span>
+                    </li>
+                    <li class="metric-card">
+                        <span class="metric-card__label">Toplanan yanıt</span>
+                        <span class="metric-card__value"><?php echo (int)$stats['responses']; ?></span>
+                        <span class="metric-card__meta">Raporlarda değerlendirildi</span>
+                    </li>
+                    <li class="metric-card">
+                        <span class="metric-card__label">Bekleyen davet</span>
+                        <span class="metric-card__value"><?php echo (int)$stats['pending']; ?></span>
+                        <span class="metric-card__meta">Takip edilmeyi bekliyor</span>
+                    </li>
+                </ul>
 
-                <div class="welcome-hero__actions">
+                <div class="dashboard-hero__actions">
                     <a class="button-primary" href="survey_edit.php">Yeni Anket Oluştur</a>
                     <?php if (!empty($primarySurvey['id'])): ?>
                         <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$primarySurvey['id']; ?>">Soruları düzenle</a>
@@ -109,11 +113,11 @@ include __DIR__ . '/templates/navbar.php';
                 </div>
             </div>
 
-            <aside class="welcome-hero__panels">
-                <div class="welcome-panel welcome-panel--ai">
-                    <span class="welcome-panel__badge">Yapay zekâ</span>
-                    <h2>Yapılandırma Özeti</h2>
-                    <dl class="ai-config__list">
+            <aside class="dashboard-hero__secondary">
+                <div class="dashboard-card dashboard-card--ai">
+                    <span class="dashboard-card__eyebrow">Yapay zekâ</span>
+                    <h2 class="dashboard-card__title">Yapılandırma Özeti</h2>
+                    <dl class="dashboard-card__list">
                         <div>
                             <dt>Sağlayıcı</dt>
                             <dd><?php echo h($aiProviderLabel); ?></dd>
@@ -138,17 +142,17 @@ include __DIR__ . '/templates/navbar.php';
                         <?php endif; ?>
                     </dl>
                     <?php if (current_user_role() === 'super_admin'): ?>
-                        <a class="button-secondary welcome-panel__cta" href="system_settings.php">Genel ayarları yönet</a>
+                        <a class="button-secondary" href="system_settings.php">Genel ayarları yönet</a>
                     <?php else: ?>
-                        <p class="welcome-panel__hint">Genel ayarlar süper yönetici tarafından yönetilir.</p>
+                        <p class="dashboard-card__hint">Genel ayarlar süper yönetici tarafından yönetilir.</p>
                     <?php endif; ?>
                 </div>
 
-                <div class="welcome-panel welcome-panel--spotlight">
+                <div class="dashboard-card dashboard-card--spotlight">
                     <?php if ($primarySurvey): ?>
-                        <span class="welcome-panel__badge">Odak anket</span>
-                        <h2><?php echo h($primarySurvey['title']); ?></h2>
-                        <ul class="spotlight-meta">
+                        <span class="dashboard-card__eyebrow">Odak anket</span>
+                        <h2 class="dashboard-card__title"><?php echo h($primarySurvey['title']); ?></h2>
+                        <ul class="spotlight-list">
                             <li>
                                 <span>Durum</span>
                                 <strong class="status-pill status-<?php echo h($primarySurvey['status']); ?>"><?php echo h($primarySurvey['status']); ?></strong>
@@ -158,15 +162,15 @@ include __DIR__ . '/templates/navbar.php';
                                 <strong><?php echo $primarySurvey['start_date'] ? h(format_date($primarySurvey['start_date'])) : '-'; ?> — <?php echo $primarySurvey['end_date'] ? h(format_date($primarySurvey['end_date'])) : '-'; ?></strong>
                             </li>
                         </ul>
-                        <div class="welcome-panel__actions">
+                        <div class="dashboard-card__actions">
                             <a class="button-secondary" href="participants.php?id=<?php echo (int)$primarySurvey['id']; ?>">Katılımcıları yönet</a>
                             <a class="button-link" href="survey_edit.php?id=<?php echo (int)$primarySurvey['id']; ?>">Detayları düzenle</a>
                         </div>
                     <?php else: ?>
-                        <span class="welcome-panel__badge">Başlangıç</span>
-                        <h2>İlk anketini başlat</h2>
+                        <span class="dashboard-card__eyebrow">Başlangıç</span>
+                        <h2 class="dashboard-card__title">İlk anketini başlat</h2>
                         <p>Katılımcı deneyimini izlemek için yeni bir anket oluştur, davetleri planla ve raporları takip et.</p>
-                        <div class="welcome-panel__actions">
+                        <div class="dashboard-card__actions">
                             <a class="button-secondary" href="survey_edit.php">Anket oluştur</a>
                         </div>
                     <?php endif; ?>
@@ -175,80 +179,111 @@ include __DIR__ . '/templates/navbar.php';
         </div>
     </section>
 
-    <section class="dashboard-panels">
-        <div class="panels-grid">
-            <div class="panel panel--surveys">
-                <header class="panel__header">
-                    <div>
-                        <h2>Son anketler</h2>
-                        <p class="panel__description">Ekibinin güncel çalışmalarını takip ederek hızlıca aksiyon al.</p>
-                    </div>
-                    <a class="button-link" href="surveys.php">Tümünü gör</a>
-                </header>
+    <section class="dashboard-overview">
+        <header class="dashboard-section__header">
+            <h2>İhtiyaçlarınıza odaklanan araçlar</h2>
+            <p>Anketlerin yaşam döngüsünü uçtan uca yönetirken modern bir deneyim sunuyoruz.</p>
+        </header>
 
-                <?php if (empty($recentSurveys)): ?>
-                    <div class="empty-block">
-                        <h3>Henüz anket oluşturulmadı</h3>
-                        <p>İlk anketini oluşturduğunda burada özetini göreceksin.</p>
-                        <a class="button-primary" href="survey_edit.php">Anket oluştur</a>
-                    </div>
-                <?php else: ?>
-                    <div class="survey-cards">
-                        <?php foreach ($recentSurveys as $survey): ?>
-                            <article class="survey-card">
-                                <div class="survey-card__top">
-                                    <div>
-                                        <h3 class="survey-card__title"><?php echo h($survey['title']); ?></h3>
-                                        <span class="survey-card__category"><?php echo h($survey['category_name'] ?? 'Genel'); ?></span>
-                                    </div>
-                                    <span class="status-pill status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
+        <div class="overview-grid">
+            <article class="overview-card">
+                <span class="overview-card__icon">🎯</span>
+                <h3>Akıllı planlama</h3>
+                <p>Kitle segmentlerini seçip davetleri zamanlayarak etkileşimi doğru anda yakalayın.</p>
+            </article>
+            <article class="overview-card">
+                <span class="overview-card__icon">📊</span>
+                <h3>Derin raporlar</h3>
+                <p>Yapay zekâ destekli özetlerle yanıtları okuyup karar süreçlerini hızlandırın.</p>
+            </article>
+            <article class="overview-card">
+                <span class="overview-card__icon">🤝</span>
+                <h3>Takım uyumu</h3>
+                <p>Rollere göre kısıtlanan erişimle ekibini aynı anda güvenle çalıştırın.</p>
+            </article>
+        </div>
+    </section>
+
+    <section class="dashboard-main">
+        <div class="module-card module-card--surveys">
+            <header class="module-card__header">
+                <div>
+                    <h2>Son anketler</h2>
+                    <p class="module-card__description">Ekibinin güncel çalışmalarını takip ederek hızlıca aksiyon al.</p>
+                </div>
+                <a class="button-link" href="surveys.php">Tümünü gör</a>
+            </header>
+
+            <?php if (empty($recentSurveys)): ?>
+                <div class="empty-state">
+                    <h3>Henüz anket oluşturulmadı</h3>
+                    <p>İlk anketini oluşturduğunda burada özetini göreceksin.</p>
+                    <a class="button-primary" href="survey_edit.php">Anket oluştur</a>
+                </div>
+            <?php else: ?>
+                <div class="survey-list">
+                    <?php foreach ($recentSurveys as $survey): ?>
+                        <article class="survey-item">
+                            <header class="survey-item__header">
+                                <div>
+                                    <h3><?php echo h($survey['title']); ?></h3>
+                                    <span class="survey-item__meta"><?php echo h($survey['category_name'] ?? 'Genel'); ?></span>
                                 </div>
-                                <dl class="survey-card__meta">
-                                    <div>
-                                        <dt>Başlangıç</dt>
-                                        <dd><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></dd>
-                                    </div>
-                                    <div>
-                                        <dt>Bitiş</dt>
-                                        <dd><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></dd>
-                                    </div>
-                                </dl>
-                                <div class="survey-card__actions">
-                                    <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Soruları yönet</a>
-                                    <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Detayları düzenle</a>
+                                <span class="status-pill status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
+                            </header>
+                            <dl class="survey-item__dates">
+                                <div>
+                                    <dt>Başlangıç</dt>
+                                    <dd><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></dd>
                                 </div>
-                            </article>
-                        <?php endforeach; ?>
+                                <div>
+                                    <dt>Bitiş</dt>
+                                    <dd><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></dd>
+                                </div>
+                            </dl>
+                            <div class="survey-item__actions">
+                                <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Soruları yönet</a>
+                                <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Detayları düzenle</a>
+                            </div>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </div>
+
+        <aside class="dashboard-sidebar">
+            <div class="module-card module-card--actions">
+                <header class="module-card__header">
+                    <div>
+                        <h2>Hızlı işlemler</h2>
+                        <p class="module-card__description">Planınıza hız kazandırın ve sık yapılan işleri dakikalara indirin.</p>
                     </div>
-                <?php endif; ?>
+                </header>
+                <ul class="action-list">
+                    <?php foreach ($quickActions as $action): ?>
+                        <li class="action-list__item<?php echo empty($action['url']) ? ' is-disabled' : ''; ?>">
+                            <span class="action-list__icon"><?php echo h($action['icon']); ?></span>
+                            <div class="action-list__body">
+                                <strong><?php echo h($action['title']); ?></strong>
+                                <p><?php echo h($action['description']); ?></p>
+                                <?php if (!empty($action['url']) && !empty($action['label'])): ?>
+                                    <a class="button-link" href="<?php echo h($action['url']); ?>"><?php echo h($action['label']); ?></a>
+                                <?php elseif (!empty($action['hint'])): ?>
+                                    <span class="action-list__hint"><?php echo h($action['hint']); ?></span>
+                                <?php endif; ?>
+                            </div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
             </div>
 
-            <aside class="panel panel--sidebar">
-                <div class="quick-actions">
-                    <h2>Hızlı işlemler</h2>
-                    <ul>
-                        <?php foreach ($quickActions as $action): ?>
-                            <li>
-                                <span class="quick-actions__icon"><?php echo h($action['icon']); ?></span>
-                                <div>
-                                    <strong><?php echo h($action['title']); ?></strong>
-                                    <p><?php echo h($action['description']); ?></p>
-                                    <?php if (!empty($action['url']) && !empty($action['label'])): ?>
-                                        <a class="button-link" href="<?php echo h($action['url']); ?>"><?php echo h($action['label']); ?></a>
-                                    <?php endif; ?>
-                                </div>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                </div>
-
-                <div class="support-callout">
-                    <strong>Desteğe mi ihtiyacın var?</strong>
-                    <p>Sürece dair sorularında ekibimize <a href="mailto:support@anketor.com">support@anketor.com</a> adresinden ulaşabilirsin.</p>
-                    <p>Yardım merkezindeki rehberlerle yeni özellikleri de keşfedebilirsin.</p>
-                </div>
-            </aside>
-        </div>
+            <div class="module-card support-card">
+                <h2>Destek ekibimiz yanında</h2>
+                <p>Soruların için dilediğin zaman <a href="mailto:support@anketor.com">support@anketor.com</a> adresine yazabilirsin.</p>
+                <a class="button-secondary" href="mailto:support@anketor.com">support@anketor.com</a>
+                <p class="support-card__meta">Yardım merkezindeki rehberlerle yeni özellikleri keşfetmeyi unutma.</p>
+            </div>
+        </aside>
     </section>
 </main>
 <?php include __DIR__ . '/templates/footer.php'; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -56,35 +56,39 @@ $flash = get_flash();
 include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
 ?>
-<main class="dashboard">
+<main class="dashboard-shell">
     <?php if ($flash): ?>
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
     <?php endif; ?>
 
     <section class="dashboard-hero">
-        <div class="dashboard-hero__inner">
-            <div class="dashboard-hero__intro">
-                <span class="dashboard-hero__eyebrow">Kontrol Merkezi</span>
+        <div class="dashboard-hero__grid">
+            <div class="dashboard-hero__content">
+                <span class="dashboard-hero__badge">Kontrol Merkezi</span>
                 <h1>Hoş geldin <?php echo h(current_user_name()); ?> 👋</h1>
                 <p class="dashboard-hero__lead">
-                    <?php echo (int)$stats['active']; ?> aktif anket ve <?php echo (int)$stats['pending']; ?> bekleyen davetle ekibinin nabzını tut. Süreci hızlandırmak için öne çıkan aksiyonları değerlendirebilirsin.
+                    <?php echo (int)$stats['active']; ?> aktif anket ve <?php echo (int)$stats['pending']; ?> bekleyen davetle <strong><?php echo h(config('app.name', 'Anketor')); ?></strong> topluluk nabzını tutuyor. Hızlı aksiyonlar için öne çıkan kartları değerlendirebilirsin.
                 </p>
 
-                <div class="dashboard-hero__stats">
-                    <div class="hero-chip">
-                        <span class="hero-chip__label">Yanıt Oranı</span>
-                        <span class="hero-chip__value"><?php echo $totalInvites > 0 ? h($responseRate) . '%': 'N/A'; ?></span>
-                        <span class="hero-chip__progress" aria-hidden="true">
+                <div class="dashboard-hero__highlights">
+                    <article class="highlight-card">
+                        <span class="highlight-card__label">Yanıt oranı</span>
+                        <span class="highlight-card__value"><?php echo $totalInvites > 0 ? h($responseRate) . '%' : 'N/A'; ?></span>
+                        <span class="highlight-card__meta"><?php echo $totalInvites > 0 ? h($totalInvites) . ' toplam davet' : 'Henüz davet gönderilmedi'; ?></span>
+                        <span class="highlight-card__progress" aria-hidden="true">
                             <span style="width: <?php echo max(8, min(100, $responseRate)); ?>%"></span>
                         </span>
-                    </div>
-                    <div class="hero-chip">
-                        <span class="hero-chip__label">Son Anket</span>
-                        <span class="hero-chip__value"><?php echo $primarySurvey ? h($primarySurvey['title']) : 'Henüz oluşturulmadı'; ?></span>
-                        <?php if (!empty($primarySurvey['start_date'])): ?>
-                            <span class="hero-chip__meta">Başlangıç: <?php echo h(format_date($primarySurvey['start_date'])); ?></span>
-                        <?php endif; ?>
-                    </div>
+                    </article>
+                    <article class="highlight-card">
+                        <span class="highlight-card__label">Aktif anket</span>
+                        <span class="highlight-card__value"><?php echo (int)$stats['active']; ?></span>
+                        <span class="highlight-card__meta"><?php echo (int)$stats['surveys']; ?> toplam anket içinde yayında.</span>
+                    </article>
+                    <article class="highlight-card">
+                        <span class="highlight-card__label">Bekleyen davet</span>
+                        <span class="highlight-card__value"><?php echo (int)$stats['pending']; ?></span>
+                        <span class="highlight-card__meta"><?php echo (int)$stats['responses']; ?> yanıt tamamlandı.</span>
+                    </article>
                 </div>
 
                 <div class="dashboard-hero__actions">
@@ -96,41 +100,39 @@ include __DIR__ . '/templates/navbar.php';
                 </div>
             </div>
 
-            <aside class="dashboard-hero__aside">
-                <div class="ai-summary">
-                    <div class="ai-summary__badge">AI</div>
-                    <div class="ai-summary__body">
-                        <h3>Yapay Zekâ Yapılandırması</h3>
-                        <dl class="ai-summary__list">
+            <div class="dashboard-hero__panel">
+                <div class="glass-card">
+                    <span class="glass-card__badge">Yapay zekâ</span>
+                    <h3>Yapılandırma Özeti</h3>
+                    <dl class="ai-config__list">
+                        <div>
+                            <dt>Sağlayıcı</dt>
+                            <dd><?php echo h($aiProviderLabel); ?></dd>
+                        </div>
+                        <?php if (!empty($aiModel)): ?>
                             <div>
-                                <dt>Sağlayıcı</dt>
-                                <dd><?php echo h($aiProviderLabel); ?></dd>
+                                <dt>Model</dt>
+                                <dd><?php echo h($aiModel); ?></dd>
                             </div>
-                            <?php if (!empty($aiModel)): ?>
-                                <div>
-                                    <dt>Model</dt>
-                                    <dd><?php echo h($aiModel); ?></dd>
-                                </div>
-                            <?php endif; ?>
-                            <?php if (!empty($aiDeployment)): ?>
-                                <div>
-                                    <dt>Deployment</dt>
-                                    <dd><?php echo h($aiDeployment); ?></dd>
-                                </div>
-                            <?php endif; ?>
-                            <?php if (!empty($aiBaseUrl)): ?>
-                                <div>
-                                    <dt>API Adresi</dt>
-                                    <dd title="<?php echo h($aiBaseUrl); ?>"><?php echo h($aiBaseUrl); ?></dd>
-                                </div>
-                            <?php endif; ?>
-                        </dl>
-                        <?php if (current_user_role() === 'super_admin'): ?>
-                            <a class="button-secondary ai-summary__action" href="system_settings.php">Genel ayarları yönet</a>
-                        <?php else: ?>
-                            <p class="ai-summary__hint">Genel ayarlar süper yönetici tarafından belirlenir.</p>
                         <?php endif; ?>
-                    </div>
+                        <?php if (!empty($aiDeployment)): ?>
+                            <div>
+                                <dt>Deployment</dt>
+                                <dd><?php echo h($aiDeployment); ?></dd>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (!empty($aiBaseUrl)): ?>
+                            <div>
+                                <dt>API Adresi</dt>
+                                <dd title="<?php echo h($aiBaseUrl); ?>"><?php echo h($aiBaseUrl); ?></dd>
+                            </div>
+                        <?php endif; ?>
+                    </dl>
+                    <?php if (current_user_role() === 'super_admin'): ?>
+                        <a class="button-secondary ai-config__action" href="system_settings.php">Genel ayarları yönet</a>
+                    <?php else: ?>
+                        <p class="ai-config__hint">Genel ayarlar süper yönetici tarafından yönetilir.</p>
+                    <?php endif; ?>
                 </div>
 
                 <?php if ($primarySurvey): ?>
@@ -146,96 +148,101 @@ include __DIR__ . '/templates/navbar.php';
                             <a class="button-link" href="survey_edit.php?id=<?php echo (int)$primarySurvey['id']; ?>">Detayları düzenle</a>
                         </div>
                     </div>
-                <?php endif; ?>
-            </aside>
-        </div>
-    </section>
-
-    <section class="insight-grid">
-        <article class="insight-card">
-            <header>
-                <span class="insight-card__label">Toplam Anket</span>
-                <span class="insight-card__trend trend-neutral">Genel görünüm</span>
-            </header>
-            <div class="insight-card__value"><?php echo (int)$stats['surveys']; ?></div>
-            <p class="insight-card__hint">Tüm zamanlarda oluşturulan anket sayısı.</p>
-        </article>
-        <article class="insight-card">
-            <header>
-                <span class="insight-card__label">Aktif Anket</span>
-                <span class="insight-card__trend trend-positive">Canlı</span>
-            </header>
-            <div class="insight-card__value"><?php echo (int)$stats['active']; ?></div>
-            <p class="insight-card__hint">Şu anda katılımcılara açık anketler.</p>
-        </article>
-        <article class="insight-card">
-            <header>
-                <span class="insight-card__label">Toplanan Cevap</span>
-                <span class="insight-card__trend trend-positive">+<?php echo (int)$stats['responses']; ?></span>
-            </header>
-            <div class="insight-card__value"><?php echo (int)$stats['responses']; ?></div>
-            <p class="insight-card__hint">Tamamlanan katılımcı yanıtları.</p>
-        </article>
-        <article class="insight-card">
-            <header>
-                <span class="insight-card__label">Bekleyen Davet</span>
-                <span class="insight-card__trend trend-warning">Takip et</span>
-            </header>
-            <div class="insight-card__value"><?php echo (int)$stats['pending']; ?></div>
-            <p class="insight-card__hint">Yanıt bekleyen davetliler.</p>
-        </article>
-    </section>
-
-    <section class="dashboard-panels">
-        <div class="panel recent-surveys">
-            <div class="panel-header">
-                <h2>Son Anketler</h2>
-                <a class="button-link" href="surveys.php">Tümünü Gör</a>
-            </div>
-            <div class="panel-body">
-                <?php if (empty($recentSurveys)): ?>
-                    <div class="empty-state">
-                        <h3>Henüz anket oluşturulmadı</h3>
-                        <p>İlk anketini oluşturduğunda burada özetini göreceksin.</p>
-                        <a class="button-primary" href="survey_edit.php">Anket oluştur</a>
-                    </div>
                 <?php else: ?>
-                    <div class="recent-surveys__list">
-                        <?php foreach ($recentSurveys as $survey): ?>
-                            <article class="survey-card">
-                                <div class="survey-card__header">
-                                    <div>
-                                        <h3><?php echo h($survey['title']); ?></h3>
-                                        <span class="survey-card__category"><?php echo h($survey['category_name'] ?? 'Genel'); ?></span>
-                                    </div>
-                                    <span class="status-pill status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
-                                </div>
-                                <ul class="survey-card__meta">
-                                    <li>
-                                        <span>Başlangıç</span>
-                                        <strong><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></strong>
-                                    </li>
-                                    <li>
-                                        <span>Bitiş</span>
-                                        <strong><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></strong>
-                                    </li>
-                                </ul>
-                                <div class="survey-card__actions">
-                                    <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Soruları yönet</a>
-                                    <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Detayları düzenle</a>
-                                </div>
-                            </article>
-                        <?php endforeach; ?>
+                    <div class="spotlight-card">
+                        <span class="spotlight-card__label">Odak alanı</span>
+                        <h3>Henüz odaklanılmış bir anket yok</h3>
+                        <p>Yeni bir anket oluşturarak raporlar ve hızlı aksiyonlar için temel veriyi oluşturabilirsin.</p>
+                        <div class="spotlight-card__actions">
+                            <a class="button-secondary" href="survey_edit.php">İlk anketini başlat</a>
+                        </div>
                     </div>
                 <?php endif; ?>
             </div>
         </div>
+    </section>
 
-        <div class="panel panel--actions">
-            <div class="panel-header">
-                <h2>Hızlı İşlemler</h2>
+    <section class="dashboard-overview">
+        <div class="overview-grid">
+            <article class="overview-card">
+                <span class="overview-card__icon">📋</span>
+                <span class="overview-card__label">Toplam anket</span>
+                <p class="overview-card__value"><?php echo (int)$stats['surveys']; ?></p>
+                <p class="overview-card__hint">Tüm ekipler tarafından bugüne kadar oluşturulan projeler.</p>
+            </article>
+            <article class="overview-card overview-card--success">
+                <span class="overview-card__icon">🚀</span>
+                <span class="overview-card__label">Aktif anket</span>
+                <p class="overview-card__value"><?php echo (int)$stats['active']; ?></p>
+                <p class="overview-card__hint">Katılımcıların şu anda erişebildiği çalışmaları temsil eder.</p>
+            </article>
+            <article class="overview-card overview-card--success">
+                <span class="overview-card__icon">✅</span>
+                <span class="overview-card__label">Toplanan cevap</span>
+                <p class="overview-card__value"><?php echo (int)$stats['responses']; ?></p>
+                <p class="overview-card__hint">İçgörüleri güçlendiren tamamlanmış geri bildirimler.</p>
+            </article>
+            <article class="overview-card overview-card--warning">
+                <span class="overview-card__icon">⏳</span>
+                <span class="overview-card__label">Bekleyen davet</span>
+                <p class="overview-card__value"><?php echo (int)$stats['pending']; ?></p>
+                <p class="overview-card__hint">Takip edilmesi gereken ve dönüş bekleyen davetliler.</p>
+            </article>
+        </div>
+    </section>
+
+    <section class="dashboard-layout">
+        <div class="surface-card">
+            <div class="surface-card__header">
+                <div>
+                    <h2>Son anketler</h2>
+                    <p class="surface-card__description">Ekibinin en güncel çalışmalarını buradan takip et.</p>
+                </div>
+                <a class="button-link" href="surveys.php">Tümünü gör</a>
             </div>
-            <div class="panel-body">
+
+            <?php if (empty($recentSurveys)): ?>
+                <div class="empty-state">
+                    <h3>Henüz anket oluşturulmadı</h3>
+                    <p>İlk anketini oluşturduğunda burada özetini göreceksin.</p>
+                    <a class="button-primary" href="survey_edit.php">Anket oluştur</a>
+                </div>
+            <?php else: ?>
+                <div class="survey-list">
+                    <?php foreach ($recentSurveys as $survey): ?>
+                        <article class="survey-item">
+                            <div class="survey-item__header">
+                                <div>
+                                    <h3 class="survey-item__title"><?php echo h($survey['title']); ?></h3>
+                                    <span class="survey-item__category"><?php echo h($survey['category_name'] ?? 'Genel'); ?></span>
+                                </div>
+                                <span class="status-pill status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
+                            </div>
+                            <ul class="survey-item__meta">
+                                <li>
+                                    <span>Başlangıç</span>
+                                    <strong><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></strong>
+                                </li>
+                                <li>
+                                    <span>Bitiş</span>
+                                    <strong><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></strong>
+                                </li>
+                            </ul>
+                            <div class="survey-item__actions">
+                                <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Soruları yönet</a>
+                                <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Detayları düzenle</a>
+                            </div>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </div>
+
+        <aside class="dashboard-layout__aside">
+            <div class="surface-card">
+                <div class="surface-card__header">
+                    <h2>Hızlı işlemler</h2>
+                </div>
                 <ul class="quick-actions-list">
                     <?php foreach ($quickActions as $action): ?>
                         <li class="quick-actions-list__item">
@@ -251,7 +258,13 @@ include __DIR__ . '/templates/navbar.php';
                     <?php endforeach; ?>
                 </ul>
             </div>
-        </div>
+
+            <div class="support-card">
+                <strong>Desteğe mi ihtiyacın var?</strong>
+                <p>Süreçleri yapılandırırken takıldığında ekibimize <a href="mailto:support@anketor.com">support@anketor.com</a> adresinden ulaşabilirsin.</p>
+                <p>Ayrıca yardım merkezindeki hızlı başlangıç rehberleriyle yeni özellikleri keşfet.</p>
+            </div>
+        </aside>
     </section>
 </main>
 <?php include __DIR__ . '/templates/footer.php'; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -28,28 +28,72 @@ $aiBaseUrl = config('ai.base_url', '');
 
 $quickActions = [
     [
-        'icon' => '🧠',
-        'title' => 'AI önerilerini güncelleyin',
-        'description' => 'Sistem ayarlarından sağlayıcıyı güncelleyerek raporlardaki içgörüleri uyarlayın.',
-        'url' => current_user_role() === 'super_admin' ? 'system_settings.php' : null,
-        'label' => 'Ayarları aç',
-        'hint' => current_user_role() === 'super_admin' ? null : 'Bu ayarı sadece süper admin güncelleyebilir.',
-    ],
-    [
-        'icon' => '🗂️',
-        'title' => 'Soru bankasını tazeleyin',
-        'description' => 'Sık kullanılan soruları düzenleyip taslaklarınıza ekleyin.',
-        'url' => 'survey_questions.php',
-        'label' => 'Soru havuzu',
+        'icon' => '📝',
+        'title' => 'Yeni anket planlayın',
+        'description' => 'Hedef kitleniz için özelleştirilmiş sorularla yeni bir çalışma başlatın.',
+        'url' => 'survey_edit.php',
+        'label' => 'Anket oluştur',
         'hint' => null,
     ],
     [
         'icon' => '📨',
-        'title' => 'Hatırlatma gönderin',
-        'description' => 'Katılım oranını artırmak için yanıt vermeyenlere toplu e-posta gönderin.',
+        'title' => 'Katılımcıları harekete geçirin',
+        'description' => 'Yanıt vermeyen kişileri belirleyip hatırlatma gönderileri planlayın.',
         'url' => $primarySurvey ? 'participants.php?id=' . (int)$primarySurvey['id'] : null,
         'label' => $primarySurvey ? 'Katılımcıları yönet' : null,
-        'hint' => $primarySurvey ? null : 'Odaklanacak bir anket seçildiğinde etkinleşir.',
+        'hint' => $primarySurvey ? null : 'Önce aktif bir anket seçin.',
+    ],
+    [
+        'icon' => '🧠',
+        'title' => 'AI yapılandırmasını gözden geçirin',
+        'description' => 'Raporlarınızın bağlamını iyileştirmek için sağlayıcı tercihlerini güncelleyin.',
+        'url' => current_user_role() === 'super_admin' ? 'system_settings.php' : null,
+        'label' => current_user_role() === 'super_admin' ? 'Genel ayarları aç' : null,
+        'hint' => current_user_role() === 'super_admin' ? null : 'Bu alan süper admin tarafından yönetilir.',
+    ],
+];
+
+$insights = [];
+if ($totalInvites === 0) {
+    $insights[] = 'Henüz davet gönderilmedi. İlk anketinizi planlayarak geri bildirim toplamaya başlayın.';
+} elseif ($responseRate < 45) {
+    $insights[] = 'Yanıt oranı %' . $responseRate . ' seviyesinde. Katılımı artırmak için hatırlatma göndermeyi değerlendirin.';
+} else {
+    $insights[] = 'Yanıt oranınız %' . $responseRate . ' ile güçlü görünüyor. Raporlarınızı düzenli olarak güncelleyin.';
+}
+
+if ((int)$stats['active'] === 0) {
+    $insights[] = 'Şu anda aktif anket bulunmuyor. Yeni bir çalışma oluşturarak panelinizi hareketlendirebilirsiniz.';
+}
+
+if ($aiProviderLabel) {
+    $insights[] = 'Rapor özetleri ' . $aiProviderLabel . ' tarafından destekleniyor. Model tercihlerini dilediğiniz zaman güncelleyebilirsiniz.';
+}
+
+$statCards = [
+    [
+        'icon' => '📋',
+        'label' => 'Toplam anket',
+        'value' => (int)$stats['surveys'],
+        'meta' => 'Yayınladığınız tüm çalışmalar',
+    ],
+    [
+        'icon' => '✨',
+        'label' => 'Aktif anket',
+        'value' => (int)$stats['active'],
+        'meta' => 'Katılımcılara açık olanlar',
+    ],
+    [
+        'icon' => '✅',
+        'label' => 'Toplanan yanıt',
+        'value' => (int)$stats['responses'],
+        'meta' => 'Raporlara işlenen kayıtlar',
+    ],
+    [
+        'icon' => '⏳',
+        'label' => 'Bekleyen davet',
+        'value' => (int)$stats['pending'],
+        'meta' => 'Yanıt bekleyen katılımcılar',
     ],
 ];
 
@@ -59,179 +103,110 @@ $flash = get_flash();
 include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
 ?>
-<main class="dashboard-shell">
+<main class="dashboard">
     <?php if ($flash): ?>
-        <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
+        <div class="dashboard__flash alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
     <?php endif; ?>
 
-    <section class="dashboard-hero">
-        <span class="dashboard-hero__halo" aria-hidden="true"></span>
-        <span class="dashboard-hero__halo dashboard-hero__halo--two" aria-hidden="true"></span>
-
-        <div class="dashboard-hero__grid">
-            <div class="dashboard-hero__primary">
-                <span class="dashboard-hero__eyebrow">Kontrol Merkezi</span>
-                <h1 class="dashboard-hero__title">Merhaba <?php echo h(current_user_name()); ?> 👋</h1>
-                <p class="dashboard-hero__lead">
-                    <?php echo (int)$stats['active']; ?> aktif anket, <?php echo (int)$stats['responses']; ?> yanıt ve <?php echo (int)$stats['pending']; ?> bekleyen davet ile <strong><?php echo h(config('app.name', 'Anketor')); ?></strong> topluluğunun nabzını tutuyoruz.
-                </p>
-
-                <ul class="dashboard-hero__metrics">
-                    <li class="metric-card metric-card--accent">
-                        <div class="metric-card__top">
-                            <span class="metric-card__label">Yanıt oranı</span>
-                            <span class="metric-card__value"><?php echo $totalInvites > 0 ? h($responseRate) . '%' : 'N/A'; ?></span>
-                        </div>
-                        <div class="metric-card__progress" aria-hidden="true">
-                            <span style="width: <?php echo max(8, min(100, $responseRate)); ?>%"></span>
-                        </div>
-                        <span class="metric-card__meta"><?php echo $totalInvites > 0 ? h($totalInvites) . ' toplam davet' : 'Henüz davet yok'; ?></span>
-                    </li>
-                    <li class="metric-card">
-                        <span class="metric-card__label">Aktif anket</span>
-                        <span class="metric-card__value"><?php echo (int)$stats['active']; ?></span>
-                        <span class="metric-card__meta"><?php echo (int)$stats['surveys']; ?> toplam anket içerisinde</span>
-                    </li>
-                    <li class="metric-card">
-                        <span class="metric-card__label">Toplanan yanıt</span>
-                        <span class="metric-card__value"><?php echo (int)$stats['responses']; ?></span>
-                        <span class="metric-card__meta">Raporlarda değerlendirildi</span>
-                    </li>
-                    <li class="metric-card">
-                        <span class="metric-card__label">Bekleyen davet</span>
-                        <span class="metric-card__value"><?php echo (int)$stats['pending']; ?></span>
-                        <span class="metric-card__meta">Takip edilmeyi bekliyor</span>
-                    </li>
-                </ul>
-
-                <div class="dashboard-hero__actions">
-                    <a class="button-primary" href="survey_edit.php">Yeni Anket Oluştur</a>
-                    <?php if (!empty($primarySurvey['id'])): ?>
-                        <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$primarySurvey['id']; ?>">Soruları düzenle</a>
-                    <?php endif; ?>
-                    <a class="button-link" href="reports.php">Raporları incele</a>
-                </div>
+    <section class="dashboard-welcome" aria-labelledby="dashboard-title">
+        <div class="dashboard-welcome__content">
+            <span class="dashboard-welcome__eyebrow">Anket yönetim merkezi</span>
+            <h1 id="dashboard-title" class="dashboard-welcome__title">Merhaba <?php echo h(current_user_name()); ?> 👋</h1>
+            <p class="dashboard-welcome__lead">
+                <?php echo (int)$stats['surveys']; ?> anket ve <?php echo (int)$stats['responses']; ?> yanıtla topluluğunuz hakkında derin içgörüler elde ediyorsunuz.
+                Kontrol paneli üzerinden süreçlerinizi hızla yönetebilirsiniz.
+            </p>
+            <div class="dashboard-welcome__actions">
+                <a class="button-primary" href="survey_edit.php">Yeni anket oluştur</a>
+                <a class="button-secondary" href="surveys.php">Anketleri yönet</a>
+                <a class="button-link" href="reports.php">Raporları incele</a>
             </div>
-
-            <aside class="dashboard-hero__secondary">
-                <div class="dashboard-card dashboard-card--ai">
-                    <span class="dashboard-card__eyebrow">Yapay zekâ</span>
-                    <h2 class="dashboard-card__title">Yapılandırma Özeti</h2>
-                    <dl class="dashboard-card__list">
-                        <div>
-                            <dt>Sağlayıcı</dt>
-                            <dd><?php echo h($aiProviderLabel); ?></dd>
-                        </div>
-                        <?php if (!empty($aiModel)): ?>
-                            <div>
-                                <dt>Model</dt>
-                                <dd><?php echo h($aiModel); ?></dd>
-                            </div>
-                        <?php endif; ?>
-                        <?php if (!empty($aiDeployment)): ?>
-                            <div>
-                                <dt>Deployment</dt>
-                                <dd><?php echo h($aiDeployment); ?></dd>
-                            </div>
-                        <?php endif; ?>
-                        <?php if (!empty($aiBaseUrl)): ?>
-                            <div>
-                                <dt>API Adresi</dt>
-                                <dd title="<?php echo h($aiBaseUrl); ?>"><?php echo h($aiBaseUrl); ?></dd>
-                            </div>
-                        <?php endif; ?>
-                    </dl>
-                    <?php if (current_user_role() === 'super_admin'): ?>
-                        <a class="button-secondary" href="system_settings.php">Genel ayarları yönet</a>
-                    <?php else: ?>
-                        <p class="dashboard-card__hint">Genel ayarlar süper yönetici tarafından yönetilir.</p>
-                    <?php endif; ?>
-                </div>
-
-                <div class="dashboard-card dashboard-card--spotlight">
-                    <?php if ($primarySurvey): ?>
-                        <span class="dashboard-card__eyebrow">Odak anket</span>
-                        <h2 class="dashboard-card__title"><?php echo h($primarySurvey['title']); ?></h2>
-                        <ul class="spotlight-list">
-                            <li>
-                                <span>Durum</span>
-                                <strong class="status-pill status-<?php echo h($primarySurvey['status']); ?>"><?php echo h($primarySurvey['status']); ?></strong>
-                            </li>
-                            <li>
-                                <span>Dönem</span>
-                                <strong><?php echo $primarySurvey['start_date'] ? h(format_date($primarySurvey['start_date'])) : '-'; ?> — <?php echo $primarySurvey['end_date'] ? h(format_date($primarySurvey['end_date'])) : '-'; ?></strong>
-                            </li>
-                        </ul>
-                        <div class="dashboard-card__actions">
-                            <a class="button-secondary" href="participants.php?id=<?php echo (int)$primarySurvey['id']; ?>">Katılımcıları yönet</a>
-                            <a class="button-link" href="survey_edit.php?id=<?php echo (int)$primarySurvey['id']; ?>">Detayları düzenle</a>
-                        </div>
-                    <?php else: ?>
-                        <span class="dashboard-card__eyebrow">Başlangıç</span>
-                        <h2 class="dashboard-card__title">İlk anketini başlat</h2>
-                        <p>Katılımcı deneyimini izlemek için yeni bir anket oluştur, davetleri planla ve raporları takip et.</p>
-                        <div class="dashboard-card__actions">
-                            <a class="button-secondary" href="survey_edit.php">Anket oluştur</a>
-                        </div>
-                    <?php endif; ?>
-                </div>
-            </aside>
-        </div>
-    </section>
-
-    <section class="dashboard-overview">
-        <header class="dashboard-section__header">
-            <h2>İhtiyaçlarınıza odaklanan araçlar</h2>
-            <p>Anketlerin yaşam döngüsünü uçtan uca yönetirken modern bir deneyim sunuyoruz.</p>
-        </header>
-
-        <div class="overview-grid">
-            <article class="overview-card">
-                <span class="overview-card__icon">🎯</span>
-                <h3>Akıllı planlama</h3>
-                <p>Kitle segmentlerini seçip davetleri zamanlayarak etkileşimi doğru anda yakalayın.</p>
-            </article>
-            <article class="overview-card">
-                <span class="overview-card__icon">📊</span>
-                <h3>Derin raporlar</h3>
-                <p>Yapay zekâ destekli özetlerle yanıtları okuyup karar süreçlerini hızlandırın.</p>
-            </article>
-            <article class="overview-card">
-                <span class="overview-card__icon">🤝</span>
-                <h3>Takım uyumu</h3>
-                <p>Rollere göre kısıtlanan erişimle ekibini aynı anda güvenle çalıştırın.</p>
-            </article>
-        </div>
-    </section>
-
-    <section class="dashboard-main">
-        <div class="module-card module-card--surveys">
-            <header class="module-card__header">
+            <dl class="dashboard-welcome__meta">
                 <div>
-                    <h2>Son anketler</h2>
-                    <p class="module-card__description">Ekibinin güncel çalışmalarını takip ederek hızlıca aksiyon al.</p>
+                    <dt>Aktif anket</dt>
+                    <dd><?php echo (int)$stats['active']; ?></dd>
+                    <small><?php echo (int)$stats['surveys']; ?> toplam çalışmadan</small>
                 </div>
-                <a class="button-link" href="surveys.php">Tümünü gör</a>
-            </header>
+                <div>
+                    <dt>Yanıt oranı</dt>
+                    <dd><?php echo $totalInvites > 0 ? h($responseRate) . '%' : 'N/A'; ?></dd>
+                    <small><?php echo $totalInvites > 0 ? h($totalInvites) . ' davet' : 'Henüz davet yok'; ?></small>
+                </div>
+                <div>
+                    <dt>Toplanan yanıt</dt>
+                    <dd><?php echo (int)$stats['responses']; ?></dd>
+                    <small>Raporlara işlendi</small>
+                </div>
+            </dl>
+        </div>
+        <div class="dashboard-welcome__panel">
+            <article class="welcome-card welcome-card--ai" aria-labelledby="ai-summary-title">
+                <span class="welcome-card__eyebrow">Yapay zekâ</span>
+                <h2 id="ai-summary-title" class="welcome-card__title"><?php echo h($aiProviderLabel); ?></h2>
+                <p class="welcome-card__lead">Seçilen sağlayıcı rapor yorumlarını ve içgörü önerilerini kişiselleştirir.</p>
+                <dl class="data-list">
+                    <?php if (!empty($aiModel)): ?>
+                        <div>
+                            <dt>Model</dt>
+                            <dd><?php echo h($aiModel); ?></dd>
+                        </div>
+                    <?php endif; ?>
+                    <?php if (!empty($aiDeployment)): ?>
+                        <div>
+                            <dt>Deployment</dt>
+                            <dd><?php echo h($aiDeployment); ?></dd>
+                        </div>
+                    <?php endif; ?>
+                    <?php if (!empty($aiBaseUrl)): ?>
+                        <div>
+                            <dt>API Adresi</dt>
+                            <dd title="<?php echo h($aiBaseUrl); ?>"><?php echo h($aiBaseUrl); ?></dd>
+                        </div>
+                    <?php endif; ?>
+                </dl>
+                <?php if (current_user_role() === 'super_admin'): ?>
+                    <a class="button-secondary" href="system_settings.php">Genel ayarları güncelle</a>
+                <?php else: ?>
+                    <p class="welcome-card__hint">Bu ayarlar süper admin tarafından düzenlenir.</p>
+                <?php endif; ?>
+            </article>
+            <article class="welcome-card welcome-card--support">
+                <h3>Destek ekibi yanınızda</h3>
+                <p>Sorularınız için bize yazın, kurulum ve rapor süreçlerini birlikte planlayalım.</p>
+                <a class="button-secondary" href="mailto:support@anketor.com">support@anketor.com</a>
+            </article>
+        </div>
+    </section>
 
-            <?php if (empty($recentSurveys)): ?>
-                <div class="empty-state">
-                    <h3>Henüz anket oluşturulmadı</h3>
-                    <p>İlk anketini oluşturduğunda burada özetini göreceksin.</p>
-                    <a class="button-primary" href="survey_edit.php">Anket oluştur</a>
+    <section class="dashboard-stats" aria-label="Kontrol paneli istatistikleri">
+        <?php foreach ($statCards as $card): ?>
+            <article class="stat-card">
+                <div class="stat-card__icon" aria-hidden="true"><?php echo $card['icon']; ?></div>
+                <div>
+                    <h3 class="stat-card__label"><?php echo h($card['label']); ?></h3>
+                    <p class="stat-card__value"><?php echo h($card['value']); ?></p>
+                    <p class="stat-card__meta"><?php echo h($card['meta']); ?></p>
                 </div>
-            <?php else: ?>
-                <div class="survey-list">
+            </article>
+        <?php endforeach; ?>
+    </section>
+
+    <div class="dashboard-layout">
+        <section class="panel">
+            <header class="panel__header">
+                <h2>Son anketler</h2>
+                <p>En güncel çalışmalarınızı burada görebilir ve hızlıca aksiyona geçebilirsiniz.</p>
+            </header>
+            <?php if ($recentSurveys): ?>
+                <ul class="survey-list">
                     <?php foreach ($recentSurveys as $survey): ?>
-                        <article class="survey-item">
-                            <header class="survey-item__header">
-                                <div>
-                                    <h3><?php echo h($survey['title']); ?></h3>
-                                    <span class="survey-item__meta"><?php echo h($survey['category_name'] ?? 'Genel'); ?></span>
-                                </div>
+                        <li class="survey-card">
+                            <div class="survey-card__header">
+                                <h3><?php echo h($survey['title']); ?></h3>
                                 <span class="status-pill status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
-                            </header>
-                            <dl class="survey-item__dates">
+                            </div>
+                            <p class="survey-card__meta">Oluşturan: <?php echo h($survey['owner_name'] ?? 'Bilinmiyor'); ?></p>
+                            <dl class="survey-card__dates">
                                 <div>
                                     <dt>Başlangıç</dt>
                                     <dd><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></dd>
@@ -241,49 +216,89 @@ include __DIR__ . '/templates/navbar.php';
                                     <dd><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></dd>
                                 </div>
                             </dl>
-                            <div class="survey-item__actions">
-                                <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Soruları yönet</a>
-                                <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Detayları düzenle</a>
+                            <div class="survey-card__actions">
+                                <a class="button-secondary" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Ayrıntıları düzenle</a>
+                                <a class="button-link" href="participants.php?id=<?php echo (int)$survey['id']; ?>">Katılımcılar</a>
                             </div>
-                        </article>
+                        </li>
                     <?php endforeach; ?>
+                </ul>
+            <?php else: ?>
+                <div class="empty-state">
+                    <h3>Henüz anket oluşturmadınız</h3>
+                    <p>Yeni bir anket planlayarak katılımcılardan geri bildirim toplamaya başlayın.</p>
+                    <a class="button-primary" href="survey_edit.php">İlk anketini oluştur</a>
                 </div>
             <?php endif; ?>
-        </div>
+        </section>
 
-        <aside class="dashboard-sidebar">
-            <div class="module-card module-card--actions">
-                <header class="module-card__header">
-                    <div>
-                        <h2>Hızlı işlemler</h2>
-                        <p class="module-card__description">Planınıza hız kazandırın ve sık yapılan işleri dakikalara indirin.</p>
-                    </div>
+        <aside class="panel-group">
+            <section class="panel panel--accent">
+                <header class="panel__header">
+                    <h2>Odak anket</h2>
+                    <p>Aktif çalışmalarınızdan birini yakından takip edin.</p>
                 </header>
-                <ul class="action-list">
+                <?php if ($primarySurvey): ?>
+                    <div class="focus-card">
+                        <h3><?php echo h($primarySurvey['title']); ?></h3>
+                        <dl>
+                            <div>
+                                <dt>Durum</dt>
+                                <dd><span class="status-pill status-<?php echo h($primarySurvey['status']); ?>"><?php echo h($primarySurvey['status']); ?></span></dd>
+                            </div>
+                            <div>
+                                <dt>Dönem</dt>
+                                <dd><?php echo $primarySurvey['start_date'] ? h(format_date($primarySurvey['start_date'])) : '-'; ?> — <?php echo $primarySurvey['end_date'] ? h(format_date($primarySurvey['end_date'])) : '-'; ?></dd>
+                            </div>
+                        </dl>
+                        <div class="focus-card__actions">
+                            <a class="button-primary" href="participants.php?id=<?php echo (int)$primarySurvey['id']; ?>">Katılımcıları yönet</a>
+                            <a class="button-link" href="survey_reports.php?id=<?php echo (int)$primarySurvey['id']; ?>">Raporu aç</a>
+                        </div>
+                    </div>
+                <?php else: ?>
+                    <div class="empty-hint">
+                        <p>Odaklanacak bir anket seçmek için yeni bir çalışma başlatın.</p>
+                    </div>
+                <?php endif; ?>
+            </section>
+
+            <section class="panel">
+                <header class="panel__header">
+                    <h2>Hızlı işlemler</h2>
+                    <p>İş akışınızı hızlandırmak için önerilen adımlar.</p>
+                </header>
+                <ul class="quick-actions">
                     <?php foreach ($quickActions as $action): ?>
-                        <li class="action-list__item<?php echo empty($action['url']) ? ' is-disabled' : ''; ?>">
-                            <span class="action-list__icon"><?php echo h($action['icon']); ?></span>
-                            <div class="action-list__body">
+                        <li class="quick-actions__item<?php echo $action['url'] ? '' : ' is-disabled'; ?>">
+                            <div class="quick-actions__icon" aria-hidden="true"><?php echo $action['icon']; ?></div>
+                            <div class="quick-actions__body">
                                 <strong><?php echo h($action['title']); ?></strong>
                                 <p><?php echo h($action['description']); ?></p>
                                 <?php if (!empty($action['url']) && !empty($action['label'])): ?>
                                     <a class="button-link" href="<?php echo h($action['url']); ?>"><?php echo h($action['label']); ?></a>
-                                <?php elseif (!empty($action['hint'])): ?>
-                                    <span class="action-list__hint"><?php echo h($action['hint']); ?></span>
+                                <?php endif; ?>
+                                <?php if (!empty($action['hint'])): ?>
+                                    <span class="quick-actions__hint"><?php echo h($action['hint']); ?></span>
                                 <?php endif; ?>
                             </div>
                         </li>
                     <?php endforeach; ?>
                 </ul>
-            </div>
+            </section>
 
-            <div class="module-card support-card">
-                <h2>Destek ekibimiz yanında</h2>
-                <p>Soruların için dilediğin zaman <a href="mailto:support@anketor.com">support@anketor.com</a> adresine yazabilirsin.</p>
-                <a class="button-secondary" href="mailto:support@anketor.com">support@anketor.com</a>
-                <p class="support-card__meta">Yardım merkezindeki rehberlerle yeni özellikleri keşfetmeyi unutma.</p>
-            </div>
+            <section class="panel panel--secondary">
+                <header class="panel__header">
+                    <h2>Panel rehberi</h2>
+                    <p>Güncel metriklere göre önerilen sonraki adımlar.</p>
+                </header>
+                <ul class="insight-list">
+                    <?php foreach ($insights as $insight): ?>
+                        <li><?php echo h($insight); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </section>
         </aside>
-    </section>
+    </div>
 </main>
 <?php include __DIR__ . '/templates/footer.php'; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -13,123 +13,244 @@ $recentSurveys = $surveyService->getSurveys(5);
 $primarySurvey = $recentSurveys[0] ?? null;
 $totalInvites = (int)$stats['responses'] + (int)$stats['pending'];
 $responseRate = $totalInvites > 0 ? round(($stats['responses'] / $totalInvites) * 100) : 0;
+
+$aiProviderKey = config('ai.provider', config('openai.provider', 'openai'));
+$aiProviderLabels = [
+    'openai' => 'OpenAI',
+    'azure_openai' => 'Azure OpenAI',
+    'anthropic' => 'Anthropic Claude',
+    'google_vertex' => 'Google Vertex AI',
+];
+$aiProviderLabel = $aiProviderLabels[$aiProviderKey] ?? ucwords(str_replace('_', ' ', (string)$aiProviderKey));
+$aiModel = config('ai.model', config($aiProviderKey . '.model', 'gpt-4o'));
+$aiDeployment = config('ai.deployment', '');
+$aiBaseUrl = config('ai.base_url', '');
+
+$quickActions = [
+    [
+        'icon' => '🧠',
+        'title' => 'AI önerilerini güncelleyin',
+        'description' => 'Sistem ayarlarından sağlayıcıyı güncelleyerek raporlardaki içgörüleri uyarlayın.',
+        'url' => current_user_role() === 'super_admin' ? 'system_settings.php' : null,
+        'label' => 'Ayarları aç',
+    ],
+    [
+        'icon' => '🗂️',
+        'title' => 'Soru bankasını tazeleyin',
+        'description' => 'Sık kullanılan soruları düzenleyip taslaklarınıza ekleyin.',
+        'url' => 'survey_questions.php',
+        'label' => 'Soru havuzu',
+    ],
+    [
+        'icon' => '📨',
+        'title' => 'Hatırlatma gönderin',
+        'description' => 'Katılım oranını artırmak için yanıt vermeyenlere toplu e-posta gönderin.',
+        'url' => $primarySurvey ? 'participants.php?id=' . (int)$primarySurvey['id'] : null,
+        'label' => $primarySurvey ? 'Katılımcıları yönet' : null,
+    ],
+];
+
 $pageTitle = 'Gösterge Paneli - ' . config('app.name', 'Anketor');
 $flash = get_flash();
+
 include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
 ?>
-<main class="container">
+<main class="dashboard">
     <?php if ($flash): ?>
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
     <?php endif; ?>
 
-    <section class="hero-card">
-        <div class="hero-card__content">
-            <p class="eyebrow">Kontrol Merkezi</p>
-            <h1>Merhaba <?php echo h(current_user_name()); ?></h1>
-            <p class="hero-lead">Ekibinizin siber güvenlik nabzını buradan yönetin. <?php echo (int)$stats['active']; ?> aktif anket ve <?php echo (int)$stats['pending']; ?> bekleyen davet sizi bekliyor.</p>
-            <div class="hero-metrics">
-                <div class="metric">
-                    <span class="metric-label">Yanıt Oranı</span>
-                    <strong class="metric-value"><?php echo $totalInvites > 0 ? $responseRate . '%': 'N/A'; ?></strong>
+    <section class="dashboard-hero">
+        <div class="dashboard-hero__inner">
+            <div class="dashboard-hero__intro">
+                <span class="dashboard-hero__eyebrow">Kontrol Merkezi</span>
+                <h1>Hoş geldin <?php echo h(current_user_name()); ?> 👋</h1>
+                <p class="dashboard-hero__lead">
+                    <?php echo (int)$stats['active']; ?> aktif anket ve <?php echo (int)$stats['pending']; ?> bekleyen davetle ekibinin nabzını tut. Süreci hızlandırmak için öne çıkan aksiyonları değerlendirebilirsin.
+                </p>
+
+                <div class="dashboard-hero__stats">
+                    <div class="hero-chip">
+                        <span class="hero-chip__label">Yanıt Oranı</span>
+                        <span class="hero-chip__value"><?php echo $totalInvites > 0 ? h($responseRate) . '%': 'N/A'; ?></span>
+                        <span class="hero-chip__progress" aria-hidden="true">
+                            <span style="width: <?php echo max(8, min(100, $responseRate)); ?>%"></span>
+                        </span>
+                    </div>
+                    <div class="hero-chip">
+                        <span class="hero-chip__label">Son Anket</span>
+                        <span class="hero-chip__value"><?php echo $primarySurvey ? h($primarySurvey['title']) : 'Henüz oluşturulmadı'; ?></span>
+                        <?php if (!empty($primarySurvey['start_date'])): ?>
+                            <span class="hero-chip__meta">Başlangıç: <?php echo h(format_date($primarySurvey['start_date'])); ?></span>
+                        <?php endif; ?>
+                    </div>
                 </div>
-                <div class="metric">
-                    <span class="metric-label">Son Anket</span>
-                    <strong class="metric-value"><?php echo $primarySurvey ? h($primarySurvey['title']) : 'Henüz yok'; ?></strong>
+
+                <div class="dashboard-hero__actions">
+                    <a class="button-primary" href="survey_edit.php">Yeni Anket Oluştur</a>
+                    <?php if (!empty($primarySurvey['id'])): ?>
+                        <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$primarySurvey['id']; ?>">Soruları düzenle</a>
+                    <?php endif; ?>
+                    <a class="button-link" href="reports.php">Raporları incele</a>
                 </div>
             </div>
-            <div class="hero-actions">
-                <a class="button-primary" href="survey_edit.php">Yeni Anket Oluştur</a>
-                <?php if (!empty($primarySurvey['id'])): ?>
-                    <a class="button-secondary" href="participants.php?id=<?php echo (int)$primarySurvey['id']; ?>">Katılımcıları Yönet</a>
+
+            <aside class="dashboard-hero__aside">
+                <div class="ai-summary">
+                    <div class="ai-summary__badge">AI</div>
+                    <div class="ai-summary__body">
+                        <h3>Yapay Zekâ Yapılandırması</h3>
+                        <dl class="ai-summary__list">
+                            <div>
+                                <dt>Sağlayıcı</dt>
+                                <dd><?php echo h($aiProviderLabel); ?></dd>
+                            </div>
+                            <?php if (!empty($aiModel)): ?>
+                                <div>
+                                    <dt>Model</dt>
+                                    <dd><?php echo h($aiModel); ?></dd>
+                                </div>
+                            <?php endif; ?>
+                            <?php if (!empty($aiDeployment)): ?>
+                                <div>
+                                    <dt>Deployment</dt>
+                                    <dd><?php echo h($aiDeployment); ?></dd>
+                                </div>
+                            <?php endif; ?>
+                            <?php if (!empty($aiBaseUrl)): ?>
+                                <div>
+                                    <dt>API Adresi</dt>
+                                    <dd title="<?php echo h($aiBaseUrl); ?>"><?php echo h($aiBaseUrl); ?></dd>
+                                </div>
+                            <?php endif; ?>
+                        </dl>
+                        <?php if (current_user_role() === 'super_admin'): ?>
+                            <a class="button-secondary ai-summary__action" href="system_settings.php">Genel ayarları yönet</a>
+                        <?php else: ?>
+                            <p class="ai-summary__hint">Genel ayarlar süper yönetici tarafından belirlenir.</p>
+                        <?php endif; ?>
+                    </div>
+                </div>
+
+                <?php if ($primarySurvey): ?>
+                    <div class="spotlight-card">
+                        <span class="spotlight-card__label">Odak Anket</span>
+                        <h3><?php echo h($primarySurvey['title']); ?></h3>
+                        <ul class="spotlight-card__meta">
+                            <li><strong>Durum:</strong> <span class="status-pill status-<?php echo h($primarySurvey['status']); ?>"><?php echo h($primarySurvey['status']); ?></span></li>
+                            <li><strong>Dönem:</strong> <?php echo $primarySurvey['start_date'] ? h(format_date($primarySurvey['start_date'])) : '-'; ?> — <?php echo $primarySurvey['end_date'] ? h(format_date($primarySurvey['end_date'])) : '-'; ?></li>
+                        </ul>
+                        <div class="spotlight-card__actions">
+                            <a class="button-secondary" href="participants.php?id=<?php echo (int)$primarySurvey['id']; ?>">Katılımcıları yönet</a>
+                            <a class="button-link" href="survey_edit.php?id=<?php echo (int)$primarySurvey['id']; ?>">Detayları düzenle</a>
+                        </div>
+                    </div>
                 <?php endif; ?>
-                <a class="button-link" href="reports.php">Rapor Merkezi</a>
+            </aside>
+        </div>
+    </section>
+
+    <section class="insight-grid">
+        <article class="insight-card">
+            <header>
+                <span class="insight-card__label">Toplam Anket</span>
+                <span class="insight-card__trend trend-neutral">Genel görünüm</span>
+            </header>
+            <div class="insight-card__value"><?php echo (int)$stats['surveys']; ?></div>
+            <p class="insight-card__hint">Tüm zamanlarda oluşturulan anket sayısı.</p>
+        </article>
+        <article class="insight-card">
+            <header>
+                <span class="insight-card__label">Aktif Anket</span>
+                <span class="insight-card__trend trend-positive">Canlı</span>
+            </header>
+            <div class="insight-card__value"><?php echo (int)$stats['active']; ?></div>
+            <p class="insight-card__hint">Şu anda katılımcılara açık anketler.</p>
+        </article>
+        <article class="insight-card">
+            <header>
+                <span class="insight-card__label">Toplanan Cevap</span>
+                <span class="insight-card__trend trend-positive">+<?php echo (int)$stats['responses']; ?></span>
+            </header>
+            <div class="insight-card__value"><?php echo (int)$stats['responses']; ?></div>
+            <p class="insight-card__hint">Tamamlanan katılımcı yanıtları.</p>
+        </article>
+        <article class="insight-card">
+            <header>
+                <span class="insight-card__label">Bekleyen Davet</span>
+                <span class="insight-card__trend trend-warning">Takip et</span>
+            </header>
+            <div class="insight-card__value"><?php echo (int)$stats['pending']; ?></div>
+            <p class="insight-card__hint">Yanıt bekleyen davetliler.</p>
+        </article>
+    </section>
+
+    <section class="dashboard-panels">
+        <div class="panel recent-surveys">
+            <div class="panel-header">
+                <h2>Son Anketler</h2>
+                <a class="button-link" href="surveys.php">Tümünü Gör</a>
+            </div>
+            <div class="panel-body">
+                <?php if (empty($recentSurveys)): ?>
+                    <div class="empty-state">
+                        <h3>Henüz anket oluşturulmadı</h3>
+                        <p>İlk anketini oluşturduğunda burada özetini göreceksin.</p>
+                        <a class="button-primary" href="survey_edit.php">Anket oluştur</a>
+                    </div>
+                <?php else: ?>
+                    <div class="recent-surveys__list">
+                        <?php foreach ($recentSurveys as $survey): ?>
+                            <article class="survey-card">
+                                <div class="survey-card__header">
+                                    <div>
+                                        <h3><?php echo h($survey['title']); ?></h3>
+                                        <span class="survey-card__category"><?php echo h($survey['category_name'] ?? 'Genel'); ?></span>
+                                    </div>
+                                    <span class="status-pill status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
+                                </div>
+                                <ul class="survey-card__meta">
+                                    <li>
+                                        <span>Başlangıç</span>
+                                        <strong><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></strong>
+                                    </li>
+                                    <li>
+                                        <span>Bitiş</span>
+                                        <strong><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></strong>
+                                    </li>
+                                </ul>
+                                <div class="survey-card__actions">
+                                    <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Soruları yönet</a>
+                                    <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Detayları düzenle</a>
+                                </div>
+                            </article>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
             </div>
         </div>
-        <div class="hero-card__sidebar">
-            <h3>Hızlı İşlemler</h3>
-            <ul class="quick-actions">
-                <li>
-                    <span class="quick-actions__icon">✨</span>
-                    <span>
-                        <strong>AI önerilerini güncelleyin</strong>
-                        <small>Raporlardan manuel not ekleyerek kişisel önerileri güçlendirin.</small>
-                    </span>
-                </li>
-                <li>
-                    <span class="quick-actions__icon">🗂️</span>
-                    <span>
-                        <strong>Soru havuzunu düzenleyin</strong>
-                        <small>Hazır soruları anketlere tek tıkla ekleyin.</small>
-                    </span>
-                </li>
-                <li>
-                    <span class="quick-actions__icon">📧</span>
-                    <span>
-                        <strong>Davetleri yeniden gönderin</strong>
-                        <small>Katılım oranını artırmak için hatırlatma planlayın.</small>
-                    </span>
-                </li>
-            </ul>
-        </div>
-    </section>
 
-    <section class="stats-grid">
-        <div class="stat-card">
-            <span class="stat-label">Toplam Anket</span>
-            <span class="stat-value"><?php echo (int)$stats['surveys']; ?></span>
-        </div>
-        <div class="stat-card">
-            <span class="stat-label">Aktif Anket</span>
-            <span class="stat-value"><?php echo (int)$stats['active']; ?></span>
-        </div>
-        <div class="stat-card">
-            <span class="stat-label">Toplanan Cevap</span>
-            <span class="stat-value"><?php echo (int)$stats['responses']; ?></span>
-        </div>
-        <div class="stat-card">
-            <span class="stat-label">Bekleyen Davet</span>
-            <span class="stat-value"><?php echo (int)$stats['pending']; ?></span>
-        </div>
-    </section>
-
-    <section class="panel">
-        <div class="panel-header">
-            <h2>Son Anketler</h2>
-            <a class="button-secondary" href="surveys.php">Tümünü Gör</a>
-        </div>
-        <div class="panel-body">
-            <?php if (empty($recentSurveys)): ?>
-                <p>Henüz anket bulunmuyor.</p>
-            <?php else: ?>
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>Başlık</th>
-                            <th>Kategori</th>
-                            <th>Durum</th>
-                            <th>Başlangıç</th>
-                            <th>Bitiş</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($recentSurveys as $survey): ?>
-                            <tr>
-                                <td><?php echo h($survey['title']); ?></td>
-                                <td><?php echo h($survey['category_name'] ?? '-'); ?></td>
-                                <td><span class="status status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span></td>
-                                <td><?php echo $survey['start_date'] ? h(format_date($survey['start_date'])) : '-'; ?></td>
-                                <td><?php echo $survey['end_date'] ? h(format_date($survey['end_date'])) : '-'; ?></td>
-                                <td>
-                                    <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Düzenle</a>
-                                    <a class="button-link" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Sorular</a>
-                                </td>
-                            </tr>
-                        <?php endforeach; ?>
-                    </tbody>
-                </table>
-            <?php endif; ?>
+        <div class="panel panel--actions">
+            <div class="panel-header">
+                <h2>Hızlı İşlemler</h2>
+            </div>
+            <div class="panel-body">
+                <ul class="quick-actions-list">
+                    <?php foreach ($quickActions as $action): ?>
+                        <li class="quick-actions-list__item">
+                            <span class="quick-actions-list__icon"><?php echo h($action['icon']); ?></span>
+                            <div class="quick-actions-list__content">
+                                <strong><?php echo h($action['title']); ?></strong>
+                                <p><?php echo h($action['description']); ?></p>
+                                <?php if (!empty($action['url']) && !empty($action['label'])): ?>
+                                    <a class="button-link" href="<?php echo h($action['url']); ?>"><?php echo h($action['label']); ?></a>
+                                <?php endif; ?>
+                            </div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
         </div>
     </section>
 </main>

--- a/database.sql
+++ b/database.sql
@@ -7,8 +7,16 @@ CREATE TABLE IF NOT EXISTS users (
     name VARCHAR(120) NOT NULL,
     email VARCHAR(190) NOT NULL UNIQUE,
     password_hash VARCHAR(255) NOT NULL,
+    role ENUM('super_admin','admin','analyst') NOT NULL DEFAULT 'admin',
     last_login_at DATETIME NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS system_settings (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    setting_key VARCHAR(120) NOT NULL UNIQUE,
+    setting_value TEXT NULL,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -129,9 +137,17 @@ CREATE TABLE IF NOT EXISTS survey_reports (
     CONSTRAINT fk_reports_survey FOREIGN KEY (survey_id) REFERENCES surveys(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-INSERT INTO users (name, email, password_hash)
-VALUES ('Admin', 'admin@example.com', '$2y$10$Wz0sMijh1X1Fh2W0Fwuq7Ot5GDL8NcNehJIKBNB1LsY5cqK8QxSN2');
+INSERT INTO users (name, email, password_hash, role)
+VALUES ('Admin', 'admin@example.com', '$2y$10$Wz0sMijh1X1Fh2W0Fwuq7Ot5GDL8NcNehJIKBNB1LsY5cqK8QxSN2', 'super_admin');
 -- Password: ChangeMe!23
+
+INSERT INTO system_settings (setting_key, setting_value) VALUES
+    ('app.name', 'Anketor'),
+    ('app.timezone', 'Europe/Istanbul'),
+    ('ai.provider', 'openai'),
+    ('ai.model', 'gpt-4o-mini')
+ON DUPLICATE KEY UPDATE
+    setting_value = VALUES(setting_value);
 -- Demo seed data
 INSERT INTO survey_categories (id, name, description) VALUES
     (1, 'Siber Guvenlik', 'Web uygulamalari, parola ve MFA odakli calismalar'),

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -12,6 +12,7 @@ function attempt_login(Database $db, string $email, string $password): bool
 
     $_SESSION['user_id'] = $user['id'];
     $_SESSION['user_name'] = $user['name'];
+    $_SESSION['user_role'] = $user['role'] ?? 'admin';
 
     $db->execute('UPDATE users SET last_login_at = NOW() WHERE id = ?', [$user['id']]);
     return true;
@@ -37,9 +38,28 @@ function current_user_name(): string
     return $_SESSION['user_name'] ?? '';
 }
 
+function current_user_role(): string
+{
+    return $_SESSION['user_role'] ?? 'guest';
+}
+
+function is_super_admin(): bool
+{
+    return current_user_role() === 'super_admin';
+}
+
 function require_login(): void
 {
     if (!current_user_id()) {
         redirect('index.php');
+    }
+}
+
+function require_super_admin(): void
+{
+    require_login();
+    if (!is_super_admin()) {
+        set_flash('danger', 'Bu işlemi gerçekleştirmek için yetkiniz yok.');
+        redirect('dashboard.php');
     }
 }

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -20,7 +20,18 @@ require_once __DIR__ . '/auth.php';
 require_once __DIR__ . '/analytics.php';
 require_once __DIR__ . '/mailer.php';
 require_once __DIR__ . '/ai_client.php';
+require_once __DIR__ . '/services/SettingsService.php';
 require_once __DIR__ . '/services/SurveyService.php';
 
 $db = Database::getInstance($config['db']);
-$surveyService = new SurveyService($db, $config);
+$settingsService = new SettingsService($db);
+$dynamicConfig = $settingsService->asConfig();
+if (!empty($dynamicConfig)) {
+    $config = array_replace_recursive($config, $dynamicConfig);
+    $GLOBALS['config'] = $config;
+    date_default_timezone_set($config['app']['timezone'] ?? 'UTC');
+}
+
+$GLOBALS['settingsService'] = $settingsService;
+
+$surveyService = new SurveyService($db, $config, $settingsService);

--- a/includes/services/SettingsService.php
+++ b/includes/services/SettingsService.php
@@ -3,22 +3,33 @@ class SettingsService
 {
     private $db;
     private $cache;
+    private $tableEnsured;
 
     public function __construct(Database $db)
     {
         $this->db = $db;
         $this->cache = null;
+        $this->tableEnsured = false;
     }
 
     public function all(): array
     {
         if ($this->cache === null) {
-            $rows = $this->db->fetchAll('SELECT setting_key, setting_value FROM system_settings ORDER BY setting_key ASC');
-            $settings = [];
-            foreach ($rows as $row) {
-                $settings[$row['setting_key']] = $this->decodeValue($row['setting_value']);
+            try {
+                $this->ensureTableExists();
+                $rows = $this->db->fetchAll('SELECT setting_key, setting_value FROM system_settings ORDER BY setting_key ASC');
+                $settings = [];
+                foreach ($rows as $row) {
+                    $settings[$row['setting_key']] = $this->decodeValue($row['setting_value']);
+                }
+                $this->cache = $settings;
+            } catch (PDOException $exception) {
+                if ($this->isMissingTableError($exception)) {
+                    $this->cache = [];
+                } else {
+                    throw $exception;
+                }
             }
-            $this->cache = $settings;
         }
 
         return $this->cache;
@@ -32,6 +43,8 @@ class SettingsService
 
     public function setMany(array $settings): void
     {
+        $this->ensureTableExists();
+
         foreach ($settings as $key => $value) {
             $encoded = $this->encodeValue($value);
             $exists = $this->db->fetch('SELECT id FROM system_settings WHERE setting_key = ?', [$key]);
@@ -103,5 +116,31 @@ class SettingsService
         }
 
         return $value;
+    }
+
+    private function ensureTableExists(): void
+    {
+        if ($this->tableEnsured) {
+            return;
+        }
+
+        try {
+            $this->db->execute("CREATE TABLE IF NOT EXISTS system_settings (\n                id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,\n                setting_key VARCHAR(120) NOT NULL UNIQUE,\n                setting_value TEXT NULL,\n                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP\n            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+        } catch (PDOException $exception) {
+            if (!$this->isMissingTableError($exception) && $exception->getCode() !== '42S01') {
+                throw $exception;
+            }
+        }
+
+        $this->tableEnsured = true;
+    }
+
+    private function isMissingTableError(PDOException $exception): bool
+    {
+        if ($exception->getCode() === '42S02') {
+            return true;
+        }
+
+        return stripos($exception->getMessage(), 'Base table or view not found') !== false;
     }
 }

--- a/includes/services/SettingsService.php
+++ b/includes/services/SettingsService.php
@@ -1,0 +1,107 @@
+<?php
+class SettingsService
+{
+    private $db;
+    private $cache;
+
+    public function __construct(Database $db)
+    {
+        $this->db = $db;
+        $this->cache = null;
+    }
+
+    public function all(): array
+    {
+        if ($this->cache === null) {
+            $rows = $this->db->fetchAll('SELECT setting_key, setting_value FROM system_settings ORDER BY setting_key ASC');
+            $settings = [];
+            foreach ($rows as $row) {
+                $settings[$row['setting_key']] = $this->decodeValue($row['setting_value']);
+            }
+            $this->cache = $settings;
+        }
+
+        return $this->cache;
+    }
+
+    public function get(string $key, $default = null)
+    {
+        $settings = $this->all();
+        return array_key_exists($key, $settings) ? $settings[$key] : $default;
+    }
+
+    public function setMany(array $settings): void
+    {
+        foreach ($settings as $key => $value) {
+            $encoded = $this->encodeValue($value);
+            $exists = $this->db->fetch('SELECT id FROM system_settings WHERE setting_key = ?', [$key]);
+            if ($exists) {
+                $this->db->execute('UPDATE system_settings SET setting_value = ?, updated_at = NOW() WHERE setting_key = ?', [$encoded, $key]);
+            } else {
+                $this->db->insert('INSERT INTO system_settings (setting_key, setting_value) VALUES (?, ?)', [$key, $encoded]);
+            }
+        }
+
+        $this->cache = null;
+    }
+
+    public function asConfig(): array
+    {
+        $config = [];
+        foreach ($this->all() as $key => $value) {
+            $segments = explode('.', $key);
+            $cursor = &$config;
+            foreach ($segments as $segment) {
+                if (!isset($cursor[$segment]) || !is_array($cursor[$segment])) {
+                    $cursor[$segment] = [];
+                }
+                $cursor = &$cursor[$segment];
+            }
+            $cursor = $value;
+            unset($cursor);
+        }
+
+        return $config;
+    }
+
+    public function reload(): void
+    {
+        $this->cache = null;
+    }
+
+    private function encodeValue($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            return json_encode($value, JSON_UNESCAPED_UNICODE);
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        return (string) $value;
+    }
+
+    private function decodeValue($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim((string) $value);
+        if ($trimmed === '1' || $trimmed === '0') {
+            return $trimmed === '1';
+        }
+
+        $json = json_decode($trimmed, true);
+        if (json_last_error() === JSON_ERROR_NONE && (is_array($json) || is_object($json))) {
+            return $json;
+        }
+
+        return $value;
+    }
+}

--- a/includes/services/SurveyService.php
+++ b/includes/services/SurveyService.php
@@ -5,12 +5,15 @@ class SurveyService
     private $config;
     private $aiClient;
     private $responseAnswersHasTypeColumn = null;
+    private $settingsService;
 
-    public function __construct(Database $db, array $config)
+    public function __construct(Database $db, array $config, ?SettingsService $settingsService = null)
     {
         $this->db = $db;
         $this->config = $config;
-        $this->aiClient = new AIClient($config['openai'] ?? []);
+        $this->settingsService = $settingsService;
+        $aiConfig = $config['ai'] ?? ($config['openai'] ?? []);
+        $this->aiClient = new AIClient($aiConfig);
     }
 
     public function aiClient(): AIClient

--- a/index.php
+++ b/index.php
@@ -30,62 +30,49 @@ include __DIR__ . '/templates/header.php';
 ?>
 <main class="auth-wrapper">
     <div class="auth-panel">
-        <section class="auth-showcase" aria-labelledby="auth-showcase-title">
-            <div class="auth-showcase__header">
-                <span class="auth-eyebrow">Anket Yönetim Portalı</span>
-                <h1 id="auth-showcase-title">Verilerinizi sezgisel bir yönetim deneyimine taşıyın.</h1>
-                <p>Anketlerinizi tasarlayın, paylaşıma hazır raporlar üretin ve yapay zekâ destekli analizlerle karar süreçlerinizi hızlandırın.</p>
+        <section class="auth-visual" aria-labelledby="auth-showcase-title">
+            <div class="auth-visual__content">
+                <span class="auth-badge">Anket Yönetim Merkezi</span>
+                <div class="auth-heading">
+                    <h1 id="auth-showcase-title">Verilerinizi tek panelden yönetin.</h1>
+                    <p>Etkinliklere ait fotoğraf, video ve anket içgörülerini merkezi bir deneyimde buluşturun. Yapay zekâ destekli analizlerle saniyeler içinde aksiyona geçin.</p>
+                </div>
+                <ul class="auth-benefits" aria-label="Platform avantajları">
+                    <li>Seçtiğiniz yapay zekâ sağlayıcısıyla uyumlu raporlar oluşturun.</li>
+                    <li>Paylaşılabilir linklerle takımınızla aynı ekranda buluşun.</li>
+                    <li>Katılımcı deneyimini izleyip anında geribildirim alın.</li>
+                </ul>
             </div>
-            <div class="auth-showcase__cards" role="presentation">
-                <article class="auth-insight">
-                    <span class="auth-insight__value">3×</span>
-                    <h3 class="auth-insight__title">Daha hızlı raporlama</h3>
-                    <p class="auth-insight__text">Yapay zekâ destekli özetlerle karar alma sürenizi kısaltın.</p>
-                </article>
-                <article class="auth-insight">
-                    <span class="auth-insight__value">%99</span>
-                    <h3 class="auth-insight__title">Veri güvenliği</h3>
-                    <p class="auth-insight__text">Rol tabanlı erişim ile hassas verileriniz güvende kalsın.</p>
-                </article>
-                <article class="auth-insight">
-                    <span class="auth-insight__value">24/7</span>
-                    <h3 class="auth-insight__title">Canlı takip</h3>
-                    <p class="auth-insight__text">Katılımcı yanıtlarını gerçek zamanlı olarak izleyin.</p>
-                </article>
+            <div class="auth-support">
+                <span>Kurulum desteği mi lazım?</span>
+                <a href="mailto:support@anketor.com">support@anketor.com</a>
             </div>
-            <ul class="auth-feature-chips" aria-label="Temel özellikler">
-                <li>Çok sağlayıcılı yapay zekâ entegrasyonu</li>
-                <li>Paylaşılabilir rapor şablonları</li>
-                <li>Takım bazlı çalışma alanları</li>
-            </ul>
         </section>
-        <aside class="auth-sidebar" aria-labelledby="auth-title">
-            <div class="auth-card">
-                <div class="auth-card-header">
-                    <h2 id="auth-title">Hesabınıza Giriş Yapın</h2>
-                    <p>Yönetim paneline erişmek için kurumsal bilgilerinizi doğrulayın.</p>
+        <aside class="auth-card" aria-labelledby="auth-title">
+            <div class="auth-card-header">
+                <h2 id="auth-title">Panele Giriş Yapın</h2>
+                <p>Yönetim hesabınızla oturum açarak süper admin araçlarına erişin.</p>
+            </div>
+            <?php if ($flash): ?>
+                <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
+            <?php endif; ?>
+            <form method="POST" action="" class="auth-form">
+                <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+                <div class="form-field">
+                    <label for="email">E-posta adresi</label>
+                    <input id="email" type="email" name="email" placeholder="ornek@anketor.com" required value="<?php echo old('email'); ?>">
                 </div>
-                <?php if ($flash): ?>
-                    <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
-                <?php endif; ?>
-                <form method="POST" action="" class="auth-form">
-                    <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-                    <div class="form-field">
-                        <label for="email">E-posta adresi</label>
-                        <input id="email" type="email" name="email" placeholder="ornek@anketor.com" required value="<?php echo old('email'); ?>">
+                <div class="form-field">
+                    <div class="field-label">
+                        <label for="password">Şifre</label>
+                        <a class="field-action" href="#" aria-disabled="true">Şifremi unuttum</a>
                     </div>
-                    <div class="form-field">
-                        <div class="field-label">
-                            <label for="password">Şifre</label>
-                            <a class="field-action" href="#" aria-disabled="true">Şifremi unuttum</a>
-                        </div>
-                        <input id="password" type="password" name="password" placeholder="••••••••" required>
-                    </div>
-                    <button type="submit" class="button-primary button-block">Panele Giriş Yap</button>
-                </form>
-                <div class="auth-card-footer">
-                    <p>Destek mi gerekiyor? <a href="mailto:support@anketor.com">Destek ekibiyle iletişime geçin</a>.</p>
+                    <input id="password" type="password" name="password" placeholder="••••••••" required>
                 </div>
+                <button type="submit" class="button-primary button-block">Panele Giriş Yap</button>
+            </form>
+            <div class="auth-card-footer">
+                <p>Güvenlik için paylaşılan cihazlarda oturumu kapatmayı unutmayın.</p>
             </div>
         </aside>
     </div>

--- a/index.php
+++ b/index.php
@@ -5,6 +5,10 @@ if (current_user_id()) {
     redirect('dashboard.php');
 }
 
+$pageTitle = 'Yönetim Paneline Giriş';
+$bodyClass = 'app-body auth-body';
+$showFooter = false;
+
 $message = '';
 
 if (is_post()) {
@@ -24,24 +28,42 @@ if (is_post()) {
 $flash = $message ? ['type' => 'danger', 'message' => $message] : get_flash();
 include __DIR__ . '/templates/header.php';
 ?>
-<div class="layout-centered">
-    <div class="card card-login">
-        <h1 class="title">Anketor Giris</h1>
-        <?php if ($flash): ?>
-            <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
-        <?php endif; ?>
-        <form method="POST" action="">
-            <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-            <div class="form-group">
-                <label for="email">E-posta</label>
-                <input id="email" type="email" name="email" required value="<?php echo old('email'); ?>">
+<main class="auth-wrapper">
+    <div class="auth-panel">
+        <section class="auth-hero">
+            <span class="auth-badge">Yönetim Portalı</span>
+            <h1>Verilerinizi güçlü anket deneyimine taşıyın.</h1>
+            <p>Katılımcı yanıtlarını tek bir merkezden toplayın, yapay zekâ destekli öngörülerle raporlayın ve ekip arkadaşlarınıza kolayca paylaşın.</p>
+            <ul class="auth-features">
+                <li>Gerçek zamanlı raporlar ve paylaşıma hazır içgörüler</li>
+                <li>Yapay zekâ sağlayıcılarını tek panelden yönetin</li>
+                <li>Takımınızla güvenli ve hızlı işbirliği yapın</li>
+            </ul>
+        </section>
+        <section class="auth-card" aria-labelledby="auth-title">
+            <div class="auth-card-header">
+                <h2 id="auth-title">Hesabınıza Giriş Yapın</h2>
+                <p>Anket yönetim merkezine erişmek için bilgilerinizi girin.</p>
             </div>
-            <div class="form-group">
-                <label for="password">Sifre</label>
-                <input id="password" type="password" name="password" required>
-            </div>
-            <button type="submit" class="button-primary">Giris Yap</button>
-        </form>
+            <?php if ($flash): ?>
+                <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
+            <?php endif; ?>
+            <form method="POST" action="" class="auth-form">
+                <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+                <div class="form-field">
+                    <label for="email">E-posta adresi</label>
+                    <input id="email" type="email" name="email" placeholder="ornek@anketor.com" required value="<?php echo old('email'); ?>">
+                </div>
+                <div class="form-field">
+                    <div class="field-label">
+                        <label for="password">Şifre</label>
+                        <a class="field-action" href="#" aria-disabled="true">Şifremi unuttum</a>
+                    </div>
+                    <input id="password" type="password" name="password" placeholder="••••••••" required>
+                </div>
+                <button type="submit" class="button-primary button-block">Panele Giriş Yap</button>
+            </form>
+        </section>
     </div>
-</div>
+</main>
 <?php include __DIR__ . '/templates/footer.php'; ?>

--- a/index.php
+++ b/index.php
@@ -30,40 +30,64 @@ include __DIR__ . '/templates/header.php';
 ?>
 <main class="auth-wrapper">
     <div class="auth-panel">
-        <section class="auth-hero">
-            <span class="auth-badge">Yönetim Portalı</span>
-            <h1>Verilerinizi güçlü anket deneyimine taşıyın.</h1>
-            <p>Katılımcı yanıtlarını tek bir merkezden toplayın, yapay zekâ destekli öngörülerle raporlayın ve ekip arkadaşlarınıza kolayca paylaşın.</p>
-            <ul class="auth-features">
-                <li>Gerçek zamanlı raporlar ve paylaşıma hazır içgörüler</li>
-                <li>Yapay zekâ sağlayıcılarını tek panelden yönetin</li>
-                <li>Takımınızla güvenli ve hızlı işbirliği yapın</li>
+        <section class="auth-showcase" aria-labelledby="auth-showcase-title">
+            <div class="auth-showcase__header">
+                <span class="auth-eyebrow">Anket Yönetim Portalı</span>
+                <h1 id="auth-showcase-title">Verilerinizi sezgisel bir yönetim deneyimine taşıyın.</h1>
+                <p>Anketlerinizi tasarlayın, paylaşıma hazır raporlar üretin ve yapay zekâ destekli analizlerle karar süreçlerinizi hızlandırın.</p>
+            </div>
+            <div class="auth-showcase__cards" role="presentation">
+                <article class="auth-insight">
+                    <span class="auth-insight__value">3×</span>
+                    <h3 class="auth-insight__title">Daha hızlı raporlama</h3>
+                    <p class="auth-insight__text">Yapay zekâ destekli özetlerle karar alma sürenizi kısaltın.</p>
+                </article>
+                <article class="auth-insight">
+                    <span class="auth-insight__value">%99</span>
+                    <h3 class="auth-insight__title">Veri güvenliği</h3>
+                    <p class="auth-insight__text">Rol tabanlı erişim ile hassas verileriniz güvende kalsın.</p>
+                </article>
+                <article class="auth-insight">
+                    <span class="auth-insight__value">24/7</span>
+                    <h3 class="auth-insight__title">Canlı takip</h3>
+                    <p class="auth-insight__text">Katılımcı yanıtlarını gerçek zamanlı olarak izleyin.</p>
+                </article>
+            </div>
+            <ul class="auth-feature-chips" aria-label="Temel özellikler">
+                <li>Çok sağlayıcılı yapay zekâ entegrasyonu</li>
+                <li>Paylaşılabilir rapor şablonları</li>
+                <li>Takım bazlı çalışma alanları</li>
             </ul>
         </section>
-        <section class="auth-card" aria-labelledby="auth-title">
-            <div class="auth-card-header">
-                <h2 id="auth-title">Hesabınıza Giriş Yapın</h2>
-                <p>Anket yönetim merkezine erişmek için bilgilerinizi girin.</p>
-            </div>
-            <?php if ($flash): ?>
-                <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
-            <?php endif; ?>
-            <form method="POST" action="" class="auth-form">
-                <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-                <div class="form-field">
-                    <label for="email">E-posta adresi</label>
-                    <input id="email" type="email" name="email" placeholder="ornek@anketor.com" required value="<?php echo old('email'); ?>">
+        <aside class="auth-sidebar" aria-labelledby="auth-title">
+            <div class="auth-card">
+                <div class="auth-card-header">
+                    <h2 id="auth-title">Hesabınıza Giriş Yapın</h2>
+                    <p>Yönetim paneline erişmek için kurumsal bilgilerinizi doğrulayın.</p>
                 </div>
-                <div class="form-field">
-                    <div class="field-label">
-                        <label for="password">Şifre</label>
-                        <a class="field-action" href="#" aria-disabled="true">Şifremi unuttum</a>
+                <?php if ($flash): ?>
+                    <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
+                <?php endif; ?>
+                <form method="POST" action="" class="auth-form">
+                    <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+                    <div class="form-field">
+                        <label for="email">E-posta adresi</label>
+                        <input id="email" type="email" name="email" placeholder="ornek@anketor.com" required value="<?php echo old('email'); ?>">
                     </div>
-                    <input id="password" type="password" name="password" placeholder="••••••••" required>
+                    <div class="form-field">
+                        <div class="field-label">
+                            <label for="password">Şifre</label>
+                            <a class="field-action" href="#" aria-disabled="true">Şifremi unuttum</a>
+                        </div>
+                        <input id="password" type="password" name="password" placeholder="••••••••" required>
+                    </div>
+                    <button type="submit" class="button-primary button-block">Panele Giriş Yap</button>
+                </form>
+                <div class="auth-card-footer">
+                    <p>Destek mi gerekiyor? <a href="mailto:support@anketor.com">Destek ekibiyle iletişime geçin</a>.</p>
                 </div>
-                <button type="submit" class="button-primary button-block">Panele Giriş Yap</button>
-            </form>
-        </section>
+            </div>
+        </aside>
     </div>
 </main>
 <?php include __DIR__ . '/templates/footer.php'; ?>

--- a/surveys.php
+++ b/surveys.php
@@ -44,18 +44,22 @@ $flash = get_flash();
 include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
 ?>
-<main class="container">
-    <header class="page-header">
-        <div>
-            <p class="eyebrow">Anketler</p>
-            <h1>Stratejik Anketler</h1>
-            <p class="page-subtitle"><?php echo count($surveys); ?> kayıtlı anket ile organizasyon güvenliğini ölçün.</p>
-        </div>
-        <div class="page-header__actions">
-            <a class="button-primary" href="survey_edit.php">Yeni Anket</a>
-            <a class="button-secondary" href="dashboard.php">Gösterge Paneli</a>
+<main class="page page--surveys">
+    <header class="page-hero">
+        <div class="page-hero__content container">
+            <div class="page-hero__text">
+                <span class="page-hero__eyebrow">Anketler</span>
+                <h1 class="page-hero__title">Stratejik Anketler</h1>
+                <p class="page-hero__subtitle"><?php echo count($surveys); ?> kayıtlı anket ile organizasyon güvenliğini ölçün.</p>
+            </div>
+            <div class="page-hero__actions">
+                <a class="button-primary" href="survey_edit.php">Yeni Anket</a>
+                <a class="button-secondary" href="dashboard.php">Gösterge Paneli</a>
+            </div>
         </div>
     </header>
+
+    <div class="container">
 
     <?php if ($flash): ?>
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
@@ -92,12 +96,14 @@ include __DIR__ . '/templates/navbar.php';
             ],
         ];
         ?>
-        <section class="survey-insights" aria-label="Anket özetleri">
+        <section class="insight-grid" aria-label="Anket özetleri">
             <?php foreach ($insights as $insight): ?>
                 <article class="insight-card">
-                    <span class="insight-card__label"><?php echo h($insight['label']); ?></span>
+                    <div class="insight-card__meta">
+                        <span class="insight-card__label"><?php echo h($insight['label']); ?></span>
+                        <span class="insight-card__hint"><?php echo h($insight['hint']); ?></span>
+                    </div>
                     <strong class="insight-card__value"><?php echo h((string)$insight['value']); ?></strong>
-                    <span class="insight-card__hint"><?php echo h($insight['hint']); ?></span>
                 </article>
             <?php endforeach; ?>
         </section>
@@ -110,7 +116,7 @@ include __DIR__ . '/templates/navbar.php';
             <a class="button-primary" href="survey_edit.php">İlk anketi oluştur</a>
         </section>
     <?php else: ?>
-        <section class="survey-grid">
+        <section class="survey-grid" aria-label="Anket listesi">
             <?php foreach ($surveys as $survey): ?>
                 <?php
                 $period = $survey['start_date'] ? format_date($survey['start_date']) : '-';
@@ -129,18 +135,20 @@ include __DIR__ . '/templates/navbar.php';
                 $statusLabel = $statusLabels[$statusKey] ?? ($survey['status'] ? ucfirst((string)$survey['status']) : 'Bilinmiyor');
                 ?>
                 <article class="survey-card">
-                    <header class="survey-card__header">
-                        <div class="survey-card__status">
-                            <span class="status status-<?php echo h($statusKey ?: 'unknown'); ?>"><?php echo h($statusLabel); ?></span>
-                            <?php if (!empty($survey['created_at'])): ?>
-                                <span class="survey-card__status-date">Oluşturma: <?php echo h(format_date($survey['created_at'])); ?></span>
-                            <?php endif; ?>
-                        </div>
-                        <h2><?php echo h($survey['title']); ?></h2>
-                    </header>
-                    <?php if ($description): ?>
-                        <p class="survey-card__description"><?php echo h($description); ?></p>
-                    <?php endif; ?>
+                    <div class="survey-card__body">
+                        <header class="survey-card__header">
+                            <div class="survey-card__status">
+                                <span class="status status-<?php echo h($statusKey ?: 'unknown'); ?>"><?php echo h($statusLabel); ?></span>
+                                <?php if (!empty($survey['created_at'])): ?>
+                                    <span class="survey-card__status-date">Oluşturma: <?php echo h(format_date($survey['created_at'])); ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <h2 class="survey-card__title"><?php echo h($survey['title']); ?></h2>
+                        </header>
+                        <?php if ($description): ?>
+                            <p class="survey-card__description"><?php echo h($description); ?></p>
+                        <?php endif; ?>
+                    </div>
                     <dl class="survey-meta">
                         <div>
                             <dt>Dönem</dt>
@@ -193,6 +201,7 @@ include __DIR__ . '/templates/navbar.php';
             <?php endforeach; ?>
         </section>
     <?php endif; ?>
+    </div>
 </main>
 <?php include __DIR__ . '/templates/footer.php'; ?>
 

--- a/surveys.php
+++ b/surveys.php
@@ -3,6 +3,42 @@ require __DIR__ . '/includes/bootstrap.php';
 require_login();
 
 $surveys = $surveyService->getSurveys(200);
+$statusLabels = [
+    'draft' => 'Taslak',
+    'scheduled' => 'Planlandı',
+    'active' => 'Yayında',
+    'closed' => 'Kapatıldı',
+];
+$statusCounts = [
+    'draft' => 0,
+    'scheduled' => 0,
+    'active' => 0,
+    'closed' => 0,
+];
+$nextSurveyDate = null;
+$nextSurveyTimestamp = null;
+
+foreach ($surveys as $survey) {
+    $statusKey = strtolower((string)($survey['status'] ?? ''));
+    if (array_key_exists($statusKey, $statusCounts)) {
+        $statusCounts[$statusKey]++;
+    }
+
+    $startTimestamp = null;
+    if (!empty($survey['start_date'])) {
+        $startTimestamp = strtotime($survey['start_date']);
+    }
+
+    if ($startTimestamp !== false && $startTimestamp !== null && $startTimestamp > time()) {
+        if ($nextSurveyTimestamp === null || $startTimestamp < $nextSurveyTimestamp) {
+            $nextSurveyTimestamp = $startTimestamp;
+            $nextSurveyDate = $survey['start_date'];
+        }
+    }
+}
+
+$totalSurveys = count($surveys);
+$activeSurveys = $statusCounts['active'];
 $pageTitle = 'Anketler - ' . config('app.name', 'Anketor');
 $flash = get_flash();
 include __DIR__ . '/templates/header.php';
@@ -23,6 +59,48 @@ include __DIR__ . '/templates/navbar.php';
 
     <?php if ($flash): ?>
         <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
+    <?php endif; ?>
+
+    <?php if (!empty($surveys)): ?>
+        <?php
+        $nextSurveyHint = $nextSurveyDate ? 'Sonraki başlangıç ' . format_date($nextSurveyDate) : 'Yeni tarih ekleyin';
+        $insights = [
+            [
+                'label' => 'Toplam Anket',
+                'value' => $totalSurveys,
+                'hint' => 'Sistemde kayıtlı',
+            ],
+            [
+                'label' => 'Yayında',
+                'value' => $activeSurveys,
+                'hint' => 'Katılımcılara açık',
+            ],
+            [
+                'label' => 'Planlanan',
+                'value' => $statusCounts['scheduled'],
+                'hint' => $nextSurveyHint,
+            ],
+            [
+                'label' => 'Taslaklar',
+                'value' => $statusCounts['draft'],
+                'hint' => 'Hazır fakat yayında değil',
+            ],
+            [
+                'label' => 'Kapatıldı',
+                'value' => $statusCounts['closed'],
+                'hint' => 'Arşivlenen çalışmalar',
+            ],
+        ];
+        ?>
+        <section class="survey-insights" aria-label="Anket özetleri">
+            <?php foreach ($insights as $insight): ?>
+                <article class="insight-card">
+                    <span class="insight-card__label"><?php echo h($insight['label']); ?></span>
+                    <strong class="insight-card__value"><?php echo h((string)$insight['value']); ?></strong>
+                    <span class="insight-card__hint"><?php echo h($insight['hint']); ?></span>
+                </article>
+            <?php endforeach; ?>
+        </section>
     <?php endif; ?>
 
     <?php if (empty($surveys)): ?>
@@ -47,15 +125,22 @@ include __DIR__ . '/templates/navbar.php';
                         $description = substr($description, 0, 137) . '...';
                     }
                 }
+                $statusKey = strtolower((string)($survey['status'] ?? ''));
+                $statusLabel = $statusLabels[$statusKey] ?? ($survey['status'] ? ucfirst((string)$survey['status']) : 'Bilinmiyor');
                 ?>
                 <article class="survey-card">
                     <header class="survey-card__header">
-                        <span class="status status-<?php echo h($survey['status']); ?>"><?php echo h($survey['status']); ?></span>
+                        <div class="survey-card__status">
+                            <span class="status status-<?php echo h($statusKey ?: 'unknown'); ?>"><?php echo h($statusLabel); ?></span>
+                            <?php if (!empty($survey['created_at'])): ?>
+                                <span class="survey-card__status-date">Oluşturma: <?php echo h(format_date($survey['created_at'])); ?></span>
+                            <?php endif; ?>
+                        </div>
                         <h2><?php echo h($survey['title']); ?></h2>
-                        <?php if ($description): ?>
-                            <p><?php echo h($description); ?></p>
-                        <?php endif; ?>
                     </header>
+                    <?php if ($description): ?>
+                        <p class="survey-card__description"><?php echo h($description); ?></p>
+                    <?php endif; ?>
                     <dl class="survey-meta">
                         <div>
                             <dt>Dönem</dt>
@@ -70,12 +155,40 @@ include __DIR__ . '/templates/navbar.php';
                             <dd><?php echo h($survey['owner_name'] ?? '-'); ?></dd>
                         </div>
                     </dl>
-                    <div class="survey-card__actions">
-                        <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Sorular</a>
-                        <a class="button-secondary" href="participants.php?id=<?php echo (int)$survey['id']; ?>">Katılımcılar</a>
-                        <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Ayarlar</a>
-                        <a class="button-link" href="survey_reports.php?id=<?php echo (int)$survey['id']; ?>">Rapor</a>
-                    </div>
+                    <footer class="survey-card__footer">
+                        <div class="survey-card__chips">
+                            <?php if ($statusKey === 'active'): ?>
+                                <span class="chip chip-success">Yanıt topluyor</span>
+                            <?php elseif ($statusKey === 'scheduled'): ?>
+                                <span class="chip chip-warning">
+                                    <?php
+                                    $scheduledHint = !empty($survey['start_date'])
+                                        ? 'Başlangıç ' . format_date($survey['start_date'])
+                                        : 'Planlandı';
+                                    echo h($scheduledHint);
+                                    ?>
+                                </span>
+                            <?php elseif ($statusKey === 'draft'): ?>
+                                <span class="chip chip-muted">Taslak aşamasında</span>
+                            <?php elseif ($statusKey === 'closed'): ?>
+                                <span class="chip chip-danger">Kapatıldı</span>
+                            <?php endif; ?>
+
+                            <?php if (!empty($survey['end_date'])): ?>
+                                <span class="chip chip-muted">Bitiş: <?php echo h(format_date($survey['end_date'])); ?></span>
+                            <?php endif; ?>
+
+                            <?php if (!empty($survey['owner_name'])): ?>
+                                <span class="chip">Sorumlu: <?php echo h($survey['owner_name']); ?></span>
+                            <?php endif; ?>
+                        </div>
+                        <div class="survey-card__actions">
+                            <a class="button-secondary" href="survey_questions.php?id=<?php echo (int)$survey['id']; ?>">Sorular</a>
+                            <a class="button-secondary" href="participants.php?id=<?php echo (int)$survey['id']; ?>">Katılımcılar</a>
+                            <a class="button-link" href="survey_edit.php?id=<?php echo (int)$survey['id']; ?>">Ayarlar</a>
+                            <a class="button-link" href="survey_reports.php?id=<?php echo (int)$survey['id']; ?>">Rapor</a>
+                        </div>
+                    </footer>
                 </article>
             <?php endforeach; ?>
         </section>

--- a/surveys.php
+++ b/surveys.php
@@ -37,87 +37,170 @@ foreach ($surveys as $survey) {
     }
 }
 
+$filterKey = strtolower($_GET['status'] ?? 'all');
+$validFilters = array_merge(['all'], array_keys($statusLabels));
+if (!in_array($filterKey, $validFilters, true)) {
+    $filterKey = 'all';
+}
+
+$filteredSurveys = array_values(array_filter($surveys, function ($survey) use ($filterKey) {
+    if ($filterKey === 'all') {
+        return true;
+    }
+    $status = strtolower((string)($survey['status'] ?? ''));
+    return $status === $filterKey;
+}));
+
 $totalSurveys = count($surveys);
 $activeSurveys = $statusCounts['active'];
+$aiConfig = config('ai', config('openai', []));
+$aiProviderLabels = [
+    'openai' => 'OpenAI',
+    'azure_openai' => 'Azure OpenAI',
+    'google_gemini' => 'Google Gemini',
+    'mock' => 'Test Motoru',
+];
+$aiProviderKey = $aiConfig['provider'] ?? 'openai';
+$aiProviderLabel = $aiProviderLabels[$aiProviderKey] ?? ucfirst((string)$aiProviderKey);
+$aiModel = $aiConfig['model'] ?? 'gpt-4o-mini';
+$aiActive = !empty($aiConfig['api_key']);
+$aiStatusLabel = $aiActive ? 'Aktif' : 'Pasif';
+$aiStatusClass = $aiActive ? 'status-badge--active' : 'status-badge--inactive';
+$nextSurveyHint = $nextSurveyDate ? 'Sonraki başlangıç ' . format_date($nextSurveyDate) : 'Yeni tarih ekleyin';
 $pageTitle = 'Anketler - ' . config('app.name', 'Anketor');
 $flash = get_flash();
 include __DIR__ . '/templates/header.php';
 include __DIR__ . '/templates/navbar.php';
 ?>
 <main class="page page--surveys">
-    <header class="page-hero">
-        <div class="page-hero__content container">
-            <div class="page-hero__text">
-                <span class="page-hero__eyebrow">Anketler</span>
-                <h1 class="page-hero__title">Stratejik Anketler</h1>
-                <p class="page-hero__subtitle"><?php echo count($surveys); ?> kayıtlı anket ile organizasyon güvenliğini ölçün.</p>
+    <section class="surveys-hero">
+        <div class="container">
+            <div class="surveys-hero__layout">
+                <div class="surveys-hero__intro">
+                    <p class="eyebrow">Anket Merkezi</p>
+                    <h1><?php echo h(config('app.name', 'Anketor')); ?> anketleri</h1>
+                    <p class="surveys-hero__subtitle"><?php echo $totalSurveys; ?> aktif kayıtlı anket ile ekiplerin nabzını tutun, güvenlik kültürünü güçlendirin.</p>
+                    <div class="surveys-hero__actions">
+                        <a class="button-primary" href="survey_edit.php">Yeni Anket Oluştur</a>
+                        <a class="button-secondary" href="dashboard.php">Gösterge Paneline Dön</a>
+                    </div>
+                </div>
+                <aside class="surveys-hero__ai" aria-label="Yapay zeka yapılandırması">
+                    <div class="ai-card">
+                        <header class="ai-card__header">
+                            <span class="ai-card__title">Yapay Zeka Motoru</span>
+                            <span class="status-badge <?php echo $aiStatusClass; ?>"><?php echo h($aiStatusLabel); ?></span>
+                        </header>
+                        <dl class="ai-card__meta">
+                            <div>
+                                <dt>Sağlayıcı</dt>
+                                <dd><?php echo h($aiProviderLabel); ?></dd>
+                            </div>
+                            <div>
+                                <dt>Model</dt>
+                                <dd><?php echo h($aiModel); ?></dd>
+                            </div>
+                            <div>
+                                <dt>Öneri Durumu</dt>
+                                <dd><?php echo $aiActive ? 'Akıllı raporlar hazır.' : 'Anahtar girmeden öneriler sınırlı.'; ?></dd>
+                            </div>
+                        </dl>
+                        <?php if (is_super_admin()): ?>
+                            <a class="ai-card__link" href="system_settings.php">Ayarları yönet</a>
+                        <?php endif; ?>
+                    </div>
+                </aside>
             </div>
-            <div class="page-hero__actions">
-                <a class="button-primary" href="survey_edit.php">Yeni Anket</a>
-                <a class="button-secondary" href="dashboard.php">Gösterge Paneli</a>
-            </div>
+
+            <?php if (!empty($surveys)): ?>
+                <?php
+                $insights = [
+                    [
+                        'label' => 'Toplam Anket',
+                        'value' => $totalSurveys,
+                        'hint' => 'Sistemde kayıtlı',
+                    ],
+                    [
+                        'label' => 'Yayında',
+                        'value' => $activeSurveys,
+                        'hint' => 'Katılımcılara açık',
+                    ],
+                    [
+                        'label' => 'Planlanan',
+                        'value' => $statusCounts['scheduled'],
+                        'hint' => $nextSurveyHint,
+                    ],
+                    [
+                        'label' => 'Taslaklar',
+                        'value' => $statusCounts['draft'],
+                        'hint' => 'Hazırlık aşamasında',
+                    ],
+                    [
+                        'label' => 'Kapatıldı',
+                        'value' => $statusCounts['closed'],
+                        'hint' => 'Arşivlenen çalışmalar',
+                    ],
+                ];
+                ?>
+                <div class="surveys-hero__metrics" aria-label="Anket özetleri">
+                    <?php foreach ($insights as $insight): ?>
+                        <article class="metric-card">
+                            <header>
+                                <span class="metric-card__label"><?php echo h($insight['label']); ?></span>
+                                <span class="metric-card__hint"><?php echo h($insight['hint']); ?></span>
+                            </header>
+                            <strong class="metric-card__value"><?php echo h((string)$insight['value']); ?></strong>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
         </div>
-    </header>
+    </section>
 
     <div class="container">
+        <?php if ($flash): ?>
+            <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
+        <?php endif; ?>
 
-    <?php if ($flash): ?>
-        <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
-    <?php endif; ?>
+        <?php if (empty($surveys)): ?>
+            <section class="empty-state">
+                <h2>Henüz anket oluşturulmadı</h2>
+                <p>Hazır soru havuzunu kullanarak dakikalar içinde ilk anketinizi yayınlayabilirsiniz.</p>
+                <a class="button-primary" href="survey_edit.php">İlk anketi oluştur</a>
+            </section>
+        <?php else: ?>
+            <?php
+            $filterTabs = [
+                ['key' => 'all', 'label' => 'Tümü', 'count' => $totalSurveys],
+            ];
+            foreach ($statusLabels as $key => $label) {
+                $filterTabs[] = [
+                    'key' => $key,
+                    'label' => $label,
+                    'count' => $statusCounts[$key] ?? 0,
+                ];
+            }
+            ?>
+            <div class="surveys-toolbar" role="toolbar" aria-label="Anket filtreleri">
+                <div class="surveys-toolbar__filters">
+                    <?php foreach ($filterTabs as $tab): ?>
+                        <a class="filter-chip <?php echo $filterKey === $tab['key'] ? 'is-active' : ''; ?>" href="?status=<?php echo h($tab['key']); ?>">
+                            <span><?php echo h($tab['label']); ?></span>
+                            <span class="filter-chip__count"><?php echo (int)$tab['count']; ?></span>
+                        </a>
+                    <?php endforeach; ?>
+                </div>
+                <div class="surveys-toolbar__context">
+                    <?php if ($filterKey === 'all'): ?>
+                        <span class="toolbar-hint">Tüm anketler gösteriliyor.</span>
+                    <?php else: ?>
+                        <span class="toolbar-hint"><?php echo h($statusLabels[$filterKey] ?? 'Seçim'); ?> statüsünde <?php echo count($filteredSurveys); ?> sonuç.</span>
+                    <?php endif; ?>
+                </div>
+            </div>
 
-    <?php if (!empty($surveys)): ?>
-        <?php
-        $nextSurveyHint = $nextSurveyDate ? 'Sonraki başlangıç ' . format_date($nextSurveyDate) : 'Yeni tarih ekleyin';
-        $insights = [
-            [
-                'label' => 'Toplam Anket',
-                'value' => $totalSurveys,
-                'hint' => 'Sistemde kayıtlı',
-            ],
-            [
-                'label' => 'Yayında',
-                'value' => $activeSurveys,
-                'hint' => 'Katılımcılara açık',
-            ],
-            [
-                'label' => 'Planlanan',
-                'value' => $statusCounts['scheduled'],
-                'hint' => $nextSurveyHint,
-            ],
-            [
-                'label' => 'Taslaklar',
-                'value' => $statusCounts['draft'],
-                'hint' => 'Hazır fakat yayında değil',
-            ],
-            [
-                'label' => 'Kapatıldı',
-                'value' => $statusCounts['closed'],
-                'hint' => 'Arşivlenen çalışmalar',
-            ],
-        ];
-        ?>
-        <section class="insight-grid" aria-label="Anket özetleri">
-            <?php foreach ($insights as $insight): ?>
-                <article class="insight-card">
-                    <div class="insight-card__meta">
-                        <span class="insight-card__label"><?php echo h($insight['label']); ?></span>
-                        <span class="insight-card__hint"><?php echo h($insight['hint']); ?></span>
-                    </div>
-                    <strong class="insight-card__value"><?php echo h((string)$insight['value']); ?></strong>
-                </article>
-            <?php endforeach; ?>
-        </section>
-    <?php endif; ?>
-
-    <?php if (empty($surveys)): ?>
-        <section class="empty-state">
-            <h2>Henüz anket oluşturulmadı</h2>
-            <p>Hazır soru havuzunu kullanarak dakikalar içinde ilk anketinizi yayınlayabilirsiniz.</p>
-            <a class="button-primary" href="survey_edit.php">İlk anketi oluştur</a>
-        </section>
-    <?php else: ?>
-        <section class="survey-grid" aria-label="Anket listesi">
-            <?php foreach ($surveys as $survey): ?>
+            <section class="survey-grid" aria-label="Anket listesi">
+                <?php foreach ($filteredSurveys as $survey): ?>
                 <?php
                 $period = $survey['start_date'] ? format_date($survey['start_date']) : '-';
                 if (!empty($survey['end_date'])) {
@@ -134,48 +217,52 @@ include __DIR__ . '/templates/navbar.php';
                 $statusKey = strtolower((string)($survey['status'] ?? ''));
                 $statusLabel = $statusLabels[$statusKey] ?? ($survey['status'] ? ucfirst((string)$survey['status']) : 'Bilinmiyor');
                 ?>
+                $progressMap = [
+                    'draft' => 25,
+                    'scheduled' => 55,
+                    'active' => 85,
+                    'closed' => 100,
+                ];
+                $progress = $progressMap[$statusKey] ?? 40;
+                $scheduledHint = '';
+                if ($statusKey === 'scheduled') {
+                    $scheduledHint = !empty($survey['start_date']) ? 'Başlangıç ' . format_date($survey['start_date']) : 'Planlandı';
+                }
+                ?>
                 <article class="survey-card">
+                    <div class="survey-card__progress" style="--progress: <?php echo (int)$progress; ?>%"></div>
                     <div class="survey-card__body">
                         <header class="survey-card__header">
-                            <div class="survey-card__status">
-                                <span class="status status-<?php echo h($statusKey ?: 'unknown'); ?>"><?php echo h($statusLabel); ?></span>
-                                <?php if (!empty($survey['created_at'])): ?>
-                                    <span class="survey-card__status-date">Oluşturma: <?php echo h(format_date($survey['created_at'])); ?></span>
-                                <?php endif; ?>
-                            </div>
-                            <h2 class="survey-card__title"><?php echo h($survey['title']); ?></h2>
+                            <span class="status status-<?php echo h($statusKey ?: 'unknown'); ?>"><?php echo h($statusLabel); ?></span>
+                            <?php if (!empty($survey['created_at'])): ?>
+                                <span class="survey-card__timestamp">Oluşturma: <?php echo h(format_date($survey['created_at'])); ?></span>
+                            <?php endif; ?>
                         </header>
+                        <h2 class="survey-card__title"><?php echo h($survey['title']); ?></h2>
                         <?php if ($description): ?>
                             <p class="survey-card__description"><?php echo h($description); ?></p>
                         <?php endif; ?>
+                        <dl class="survey-card__meta">
+                            <div>
+                                <dt>Dönem</dt>
+                                <dd><?php echo h($period); ?></dd>
+                            </div>
+                            <div>
+                                <dt>Kategori</dt>
+                                <dd><?php echo h($survey['category_name'] ?? '-'); ?></dd>
+                            </div>
+                            <div>
+                                <dt>Sahip</dt>
+                                <dd><?php echo h($survey['owner_name'] ?? '-'); ?></dd>
+                            </div>
+                        </dl>
                     </div>
-                    <dl class="survey-meta">
-                        <div>
-                            <dt>Dönem</dt>
-                            <dd><?php echo h($period); ?></dd>
-                        </div>
-                        <div>
-                            <dt>Kategori</dt>
-                            <dd><?php echo h($survey['category_name'] ?? '-'); ?></dd>
-                        </div>
-                        <div>
-                            <dt>Sahip</dt>
-                            <dd><?php echo h($survey['owner_name'] ?? '-'); ?></dd>
-                        </div>
-                    </dl>
                     <footer class="survey-card__footer">
-                        <div class="survey-card__chips">
+                        <div class="survey-card__badges">
                             <?php if ($statusKey === 'active'): ?>
                                 <span class="chip chip-success">Yanıt topluyor</span>
                             <?php elseif ($statusKey === 'scheduled'): ?>
-                                <span class="chip chip-warning">
-                                    <?php
-                                    $scheduledHint = !empty($survey['start_date'])
-                                        ? 'Başlangıç ' . format_date($survey['start_date'])
-                                        : 'Planlandı';
-                                    echo h($scheduledHint);
-                                    ?>
-                                </span>
+                                <span class="chip chip-warning"><?php echo h($scheduledHint); ?></span>
                             <?php elseif ($statusKey === 'draft'): ?>
                                 <span class="chip chip-muted">Taslak aşamasında</span>
                             <?php elseif ($statusKey === 'closed'): ?>
@@ -199,8 +286,12 @@ include __DIR__ . '/templates/navbar.php';
                     </footer>
                 </article>
             <?php endforeach; ?>
-        </section>
-    <?php endif; ?>
+            </section>
+
+            <?php if (empty($filteredSurveys)): ?>
+                <p class="no-results">Seçilen statüde anket bulunamadı. Farklı bir filtre deneyin.</p>
+            <?php endif; ?>
+        <?php endif; ?>
     </div>
 </main>
 <?php include __DIR__ . '/templates/footer.php'; ?>

--- a/system_settings.php
+++ b/system_settings.php
@@ -1,0 +1,209 @@
+<?php
+require __DIR__ . '/includes/bootstrap.php';
+require_super_admin();
+
+/** @var SettingsService $settingsService */
+$settingsService = $GLOBALS['settingsService'] ?? new SettingsService($db);
+
+$aiProviders = [
+    'openai' => 'OpenAI',
+    'azure_openai' => 'Azure OpenAI',
+    'google_gemini' => 'Google Gemini',
+    'mock' => 'Test / Yerel Motor',
+];
+
+$timezoneOptions = [
+    'Europe/Istanbul' => 'Europe/Istanbul',
+    'UTC' => 'UTC',
+    'Europe/Berlin' => 'Europe/Berlin',
+    'Asia/Dubai' => 'Asia/Dubai',
+    'America/New_York' => 'America/New_York',
+];
+
+$current = [
+    'app_name' => config('app.name', 'Anketor'),
+    'app_timezone' => config('app.timezone', 'Europe/Istanbul'),
+    'mail_from_name' => config('mail.from_name', ''),
+    'mail_from_email' => config('mail.from_email', ''),
+    'ai_provider' => config('ai.provider', config('openai.provider', 'openai')),
+    'ai_model' => config('ai.model', 'gpt-4o-mini'),
+    'ai_api_key' => config('ai.api_key', ''),
+    'ai_base_url' => config('ai.base_url', 'https://api.openai.com/v1'),
+    'ai_deployment' => config('ai.deployment', ''),
+    'ai_azure_api_version' => config('ai.azure_api_version', '2024-02-15-preview'),
+];
+
+$errors = [];
+
+if (is_post()) {
+    guard_csrf();
+
+    $appName = trim($_POST['app_name'] ?? '');
+    $timezone = trim($_POST['app_timezone'] ?? 'UTC');
+    $fromName = trim($_POST['mail_from_name'] ?? '');
+    $fromEmail = trim($_POST['mail_from_email'] ?? '');
+    $provider = $_POST['ai_provider'] ?? 'openai';
+    $model = trim($_POST['ai_model'] ?? '');
+    $apiKey = trim($_POST['ai_api_key'] ?? '');
+    $baseUrl = trim($_POST['ai_base_url'] ?? '');
+    $deployment = trim($_POST['ai_deployment'] ?? '');
+    $apiVersion = trim($_POST['ai_azure_api_version'] ?? '');
+
+    if ($appName === '') {
+        $errors[] = 'Platform adı boş olamaz.';
+    }
+
+    if ($fromEmail !== '' && !filter_var($fromEmail, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Geçerli bir destek e-posta adresi girin.';
+    }
+
+    if (!array_key_exists($provider, $aiProviders)) {
+        $provider = 'openai';
+    }
+
+    if (!array_key_exists($timezone, $timezoneOptions)) {
+        $timezone = 'UTC';
+    }
+
+    if (empty($model)) {
+        $errors[] = 'Bir yapay zeka modeli seçin.';
+    }
+
+    if (empty($errors)) {
+        $settingsService->setMany([
+            'app.name' => $appName,
+            'app.timezone' => $timezone,
+            'mail.from_name' => $fromName,
+            'mail.from_email' => $fromEmail,
+            'ai.provider' => $provider,
+            'ai.model' => $model,
+            'ai.api_key' => $apiKey,
+            'ai.base_url' => $baseUrl,
+            'ai.deployment' => $deployment,
+            'ai.azure_api_version' => $apiVersion,
+        ]);
+
+        $settingsService->reload();
+        $merged = array_replace_recursive($config, $settingsService->asConfig());
+        $GLOBALS['config'] = $config = $merged;
+        date_default_timezone_set($config['app']['timezone'] ?? 'UTC');
+
+        set_flash('success', 'Sistem ayarları güncellendi.');
+        redirect('system_settings.php');
+    } else {
+        $current = array_merge($current, [
+            'app_name' => $appName,
+            'app_timezone' => $timezone,
+            'mail_from_name' => $fromName,
+            'mail_from_email' => $fromEmail,
+            'ai_provider' => $provider,
+            'ai_model' => $model,
+            'ai_api_key' => $apiKey,
+            'ai_base_url' => $baseUrl,
+            'ai_deployment' => $deployment,
+            'ai_azure_api_version' => $apiVersion,
+        ]);
+    }
+}
+
+$pageTitle = 'Sistem Ayarları - ' . config('app.name', 'Anketor');
+$flash = get_flash();
+
+include __DIR__ . '/templates/header.php';
+include __DIR__ . '/templates/navbar.php';
+?>
+<main class="container">
+    <header class="page-header">
+        <div>
+            <p class="eyebrow">Yönetim</p>
+            <h1>Sistem Ayarları</h1>
+            <p class="page-subtitle">Platform kimliğini, bildirim gönderen adresleri ve yapay zeka motorunu tek bir yerden yönetin.</p>
+        </div>
+    </header>
+
+    <?php if ($flash): ?>
+        <div class="alert alert-<?php echo h($flash['type']); ?>"><?php echo h($flash['message']); ?></div>
+    <?php endif; ?>
+
+    <?php if (!empty($errors)): ?>
+        <div class="alert alert-danger">
+            <?php foreach ($errors as $error): ?>
+                <div><?php echo h($error); ?></div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <form method="POST" class="settings-grid">
+        <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+
+        <section class="panel">
+            <div class="panel-header">
+                <h2>Genel Bilgiler</h2>
+            </div>
+            <div class="panel-body form-grid">
+                <div class="form-group">
+                    <label for="app_name">Platform Adı</label>
+                    <input type="text" id="app_name" name="app_name" required value="<?php echo h($current['app_name']); ?>">
+                </div>
+                <div class="form-group">
+                    <label for="app_timezone">Saat Dilimi</label>
+                    <select id="app_timezone" name="app_timezone">
+                        <?php foreach ($timezoneOptions as $key => $label): ?>
+                            <option value="<?php echo h($key); ?>" <?php echo $current['app_timezone'] === $key ? 'selected' : ''; ?>><?php echo h($label); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="mail_from_name">Bildirim Gönderen Adı</label>
+                    <input type="text" id="mail_from_name" name="mail_from_name" value="<?php echo h($current['mail_from_name']); ?>">
+                </div>
+                <div class="form-group">
+                    <label for="mail_from_email">Bildirim Gönderen E-posta</label>
+                    <input type="email" id="mail_from_email" name="mail_from_email" value="<?php echo h($current['mail_from_email']); ?>">
+                </div>
+            </div>
+        </section>
+
+        <section class="panel">
+            <div class="panel-header">
+                <h2>Yapay Zeka Motoru</h2>
+                <p class="panel-subtitle">Analiz ve raporlar için kullanılacak sağlayıcı ve erişim bilgilerini seçin.</p>
+            </div>
+            <div class="panel-body form-grid">
+                <div class="form-group">
+                    <label for="ai_provider">Sağlayıcı</label>
+                    <select id="ai_provider" name="ai_provider">
+                        <?php foreach ($aiProviders as $key => $label): ?>
+                            <option value="<?php echo h($key); ?>" <?php echo $current['ai_provider'] === $key ? 'selected' : ''; ?>><?php echo h($label); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="ai_model">Model / Deployment</label>
+                    <input type="text" id="ai_model" name="ai_model" required value="<?php echo h($current['ai_model']); ?>" placeholder="gpt-4o-mini veya benzeri">
+                </div>
+                <div class="form-group">
+                    <label for="ai_api_key">API Anahtarı</label>
+                    <input type="text" id="ai_api_key" name="ai_api_key" value="<?php echo h($current['ai_api_key']); ?>" placeholder="Gizli anahtarı buraya girin">
+                </div>
+                <div class="form-group">
+                    <label for="ai_base_url">Temel API URL</label>
+                    <input type="text" id="ai_base_url" name="ai_base_url" value="<?php echo h($current['ai_base_url']); ?>" placeholder="https://api.openai.com/v1">
+                </div>
+                <div class="form-group">
+                    <label for="ai_deployment">Azure Deployment Adı (Opsiyonel)</label>
+                    <input type="text" id="ai_deployment" name="ai_deployment" value="<?php echo h($current['ai_deployment']); ?>" placeholder="Azure için deployment adı">
+                </div>
+                <div class="form-group">
+                    <label for="ai_azure_api_version">Azure API Versiyonu (Opsiyonel)</label>
+                    <input type="text" id="ai_azure_api_version" name="ai_azure_api_version" value="<?php echo h($current['ai_azure_api_version']); ?>" placeholder="2024-02-15-preview">
+                </div>
+            </div>
+        </section>
+
+        <div class="form-actions form-actions--sticky">
+            <button type="submit" class="button-primary">Ayarları Kaydet</button>
+        </div>
+    </form>
+</main>
+<?php include __DIR__ . '/templates/footer.php'; ?>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,7 +1,9 @@
+<?php if (!isset($showFooter) || $showFooter): ?>
 <footer class="site-footer">
     <p>&copy; <?php echo date('Y'); ?> <?php echo h(config('app.name', 'Anketor')); ?>. Tüm hakları saklıdır.</p>
     <p class="help-text">Katılımcı odaklı içgörüler üretmek için tasarlandı.</p>
 </footer>
+<?php endif; ?>
 <script src="<?php echo asset_url('js/app.js'); ?>"></script>
 </body>
 </html>

--- a/templates/header.php
+++ b/templates/header.php
@@ -11,4 +11,4 @@ $pageTitle = $pageTitle ?? config('app.name', 'Anketor');
     <title><?php echo h($pageTitle); ?></title>
     <link rel="stylesheet" href="<?php echo asset_url('css/style.css'); ?>">
 </head>
-<body class="app-body">
+<body class="<?php echo h($bodyClass ?? 'app-body'); ?>">

--- a/templates/navbar.php
+++ b/templates/navbar.php
@@ -6,9 +6,12 @@
         <li><a class="<?php echo active_nav('surveys.php'); ?>" href="surveys.php">Anketler</a></li>
         <li><a class="<?php echo active_nav('reports.php'); ?>" href="reports.php">Raporlar</a></li>
         <li><a class="<?php echo active_nav('users.php'); ?>" href="users.php">Kullanıcılar</a></li>
+        <?php if (is_super_admin()): ?>
+            <li><a class="<?php echo active_nav('system_settings.php'); ?>" href="system_settings.php">Sistem Ayarları</a></li>
+        <?php endif; ?>
     </ul>
     <div class="user-meta">
-        <span><?php echo h(current_user_name()); ?></span>
+        <span><?php echo h(current_user_name()); ?> · <?php echo h(strtoupper(str_replace('_', ' ', current_user_role()))); ?></span>
         <a class="button-secondary" href="logout.php">Çıkış</a>
     </div>
 </nav>


### PR DESCRIPTION
## Summary
- add at-a-glance metrics for survey totals and statuses at the top of the page
- redesign the survey cards with clearer status badges, descriptive chips, and hover styling
- extend the stylesheet with insight card components, chip variants, and responsive tweaks for the surveys grid

## Testing
- php -l surveys.php

------
https://chatgpt.com/codex/tasks/task_e_68e315dfb524832e8ff18458066a752b